### PR TITLE
Update Vite base path for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: '/PEM-avoidance-toolkit-companion/',
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
Updated the Vite configuration to use an absolute base path for deployment on GitHub Pages, replacing the relative path with the repository-specific path.

## Key Changes
- Changed `base` configuration from `'./'` to `'/PEM-avoidance-toolkit-companion/'` in `vite.config.js`

## Implementation Details
This change ensures that the application's assets and routing work correctly when deployed to a GitHub Pages subdirectory. The new base path matches the repository name, allowing the built application to properly resolve all static assets and handle client-side routing when accessed at `https://[username].github.io/PEM-avoidance-toolkit-companion/`.

https://claude.ai/code/session_01Cy1o9NsZwCLVL2uxM22SBJ