### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+      - run: npm run build
+
+      - uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and deploy the project to GitHub Pages on every push to the main branch.

## Key Changes
- Added `.github/workflows/deploy.yml` workflow file that:
  - Triggers on pushes to the main branch
  - Sets up Node.js 20 environment
  - Installs dependencies and builds the project
  - Uploads the `dist` directory as a GitHub Pages artifact
  - Deploys the built site to GitHub Pages

## Implementation Details
- Uses GitHub's official actions for pages configuration, artifact upload, and deployment
- Includes proper permissions configuration for pages write access and OIDC token generation
- Implements concurrency controls to cancel in-progress deployments when new pushes occur
- Targets the `dist` directory as the build output for deployment

https://claude.ai/code/session_01S3h3PyqFFYkSzMZBf7W9Cr