### PR TITLE
Fix PWA manifest URL resolution in e2e tests

### DIFF
--- a/tests/e2e/pwa.test.js
+++ b/tests/e2e/pwa.test.js
@@ -10,7 +10,7 @@ test.describe('PWA Manifest', () => {
   test('manifest is fetchable and valid JSON', async ({ page }) => {
     await page.goto('/');
     const href = await page.locator('link[rel="manifest"]').getAttribute('href');
-    const res = await page.request.get(href);
+    const res = await page.request.get(new URL(href, page.url()).href);
     expect(res.ok()).toBe(true);
     const json = await res.json();
     expect(json).toBeTruthy();
@@ -19,7 +19,7 @@ test.describe('PWA Manifest', () => {
   test('manifest has required PWA fields', async ({ page }) => {
     await page.goto('/');
     const href = await page.locator('link[rel="manifest"]').getAttribute('href');
-    const res = await page.request.get(href);
+    const res = await page.request.get(new URL(href, page.url()).href);
     const manifest = await res.json();
 
     expect(manifest.name).toBeTruthy();
@@ -32,7 +32,7 @@ test.describe('PWA Manifest', () => {
   test('manifest display is standalone', async ({ page }) => {
     await page.goto('/');
     const href = await page.locator('link[rel="manifest"]').getAttribute('href');
-    const res = await page.request.get(href);
+    const res = await page.request.get(new URL(href, page.url()).href);
     const manifest = await res.json();
 
     expect(manifest.display).toBe('standalone');
@@ -41,7 +41,7 @@ test.describe('PWA Manifest', () => {
   test('manifest has icons with required properties', async ({ page }) => {
     await page.goto('/');
     const href = await page.locator('link[rel="manifest"]').getAttribute('href');
-    const res = await page.request.get(href);
+    const res = await page.request.get(new URL(href, page.url()).href);
     const manifest = await res.json();
 
     expect(manifest.icons.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
Fixed manifest URL resolution in PWA e2e tests to properly handle relative URLs by converting them to absolute URLs using the current page URL as the base.

## Changes
- Updated all four PWA manifest test cases to resolve relative manifest URLs to absolute URLs before making requests
- Changed `page.request.get(href)` to `page.request.get(new URL(href, page.url()).href)` in:
  - "manifest is fetchable and valid JSON" test
  - "manifest has required PWA fields" test
  - "manifest display is standalone" test
  - "manifest has icons with required properties" test

## Details
The manifest `href` attribute can be a relative URL (e.g., `/manifest.json`), but `page.request.get()` requires an absolute URL to work correctly. By using the `URL` constructor with the manifest href and the current page URL as the base, we ensure the request is made to the correct absolute URL regardless of whether the href is relative or absolute.

https://claude.ai/code/session_01DoZxeu9eFM6KpyK2KW7mx3