### PR TITLE
Fix e2e tests timing out due to unreachable Google Fonts

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: 'npm run build && npm run preview -- --port 4173',
+    command: 'npx vite build --base / && npx vite preview --base / --port 4173',
     port: 4173,
     reuseExistingServer: !process.env.CI,
     timeout: 60000,

--- a/tests/e2e/features.test.js
+++ b/tests/e2e/features.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './global-setup.js';
 
 // Helper: complete onboarding and dismiss tour
 async function completeOnboarding(page) {

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,13 @@
+import { test as base } from '@playwright/test';
+
+// Block external requests (e.g. Google Fonts) that may be unreachable in CI
+// and would cause page.goto to hang waiting for the load event.
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/*.googleapis.com/**', route => route.abort());
+    await page.route('**/*.gstatic.com/**', route => route.abort());
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/e2e/pwa.test.js
+++ b/tests/e2e/pwa.test.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './global-setup.js';
 
 test.describe('PWA Manifest', () => {
   test('manifest link exists in HTML', async ({ page }) => {


### PR DESCRIPTION
The e2e tests were timing out because page.goto('/') waits for the
'load' event, which never fires when Google Fonts requests hang (403
in CI). Two issues were fixed:

1. Build with --base / for e2e tests so the preview server serves at
   root, matching the test navigation paths
2. Block external font requests (googleapis.com, gstatic.com) via a
   shared Playwright fixture to prevent load event from hanging

https://claude.ai/code/session_01YAKaFPveFdPX8mXggfSvN3