### PR TITLE
Add auto-calculation for Overall Activity and Overall Symptom scores

### DIFF
--- a/src/DayEditor.jsx
+++ b/src/DayEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { formatDate, activityColor, symptomColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
+import { formatDate, activityColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
 import { SectionLabel, ScoreInput, SymptomRow, AutoScoreInput, AutoSymptomRow, BtnP, BtnS, s } from './components.jsx';
 
 function trapFocus(e, containerRef) {

--- a/src/DayEditor.jsx
+++ b/src/DayEditor.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
-import { formatDate, activityColor, symptomColor } from './utils.js';
-import { SectionLabel, ScoreInput, SymptomRow, BtnP, BtnS, s } from './components.jsx';
+import { formatDate, activityColor, symptomColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
+import { SectionLabel, ScoreInput, SymptomRow, AutoScoreInput, AutoSymptomRow, BtnP, BtnS, s } from './components.jsx';
 
 function trapFocus(e, containerRef) {
   if (e.key !== 'Tab' || !containerRef.current) return;
@@ -18,10 +18,40 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
     // Restore properties that JSON stringify removes (undefined → missing)
     if (!clone.other_symptom) clone.other_symptom = { name: '', am: '', mid: '', pm: '' };
     if (!clone.nausea_gi) clone.nausea_gi = { am: '', mid: '', pm: '' };
+    // Backward compat: existing days without override fields
+    if (clone.overrideActivity === undefined) {
+      clone.overrideActivity = clone.overall_activity !== '' && clone.overall_activity != null;
+    }
+    if (clone.overrideSymptom === undefined) {
+      const os = clone.overall_symptom || { am: '', mid: '', pm: '' };
+      clone.overrideSymptom = os.am !== '' || os.mid !== '' || os.pm !== '';
+    }
     return clone;
   });
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }));
   const setN = (k, sub, v) => setForm(f => ({ ...f, [k]: { ...f[k], [sub]: v } }));
+
+  const computedActivity = calcOverallActivity(form);
+  const computedSymptomAm = calcOverallSymptom(form, 'am');
+  const computedSymptomMid = calcOverallSymptom(form, 'mid');
+  const computedSymptomPm = calcOverallSymptom(form, 'pm');
+
+  const round1 = v => v !== null ? String(Math.round(v * 10) / 10) : '';
+
+  const handleSave = () => {
+    const out = { ...form };
+    if (!out.overrideActivity && computedActivity !== null) {
+      out.overall_activity = round1(computedActivity);
+    }
+    if (!out.overrideSymptom) {
+      out.overall_symptom = {
+        am: round1(computedSymptomAm),
+        mid: round1(computedSymptomMid),
+        pm: round1(computedSymptomPm),
+      };
+    }
+    onSave(out);
+  };
 
   return (
     <div ref={modalRef} style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.75)', zIndex: 200, display: 'flex', alignItems: 'flex-end', justifyContent: 'center' }} onClick={onCancel} onKeyDown={e => { if (e.key === 'Escape') onCancel(); trapFocus(e, modalRef); }}>
@@ -31,7 +61,7 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
           <span style={{ fontSize: 16, fontWeight: 700 }}>{formatDate(form.date)}</span>
           <div style={{ display: 'flex', gap: 8 }}>
             <BtnS onClick={onCancel}>Cancel</BtnS>
-            <BtnP onClick={() => onSave(form)}>Save</BtnP>
+            <BtnP onClick={handleSave}>Save</BtnP>
           </div>
         </div>
 
@@ -41,7 +71,10 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
           <ScoreInput label="Physical" value={form.physical} onChange={v => set('physical', v)} colorFn={activityColor} />
           <ScoreInput label="Mental" value={form.mental} onChange={v => set('mental', v)} colorFn={activityColor} />
           <ScoreInput label="Emotional" value={form.emotional} onChange={v => set('emotional', v)} colorFn={activityColor} />
-          <ScoreInput label="Overall Activity &#9733;" value={form.overall_activity} onChange={v => set('overall_activity', v)} colorFn={activityColor} highlight />
+          <AutoScoreInput label="Overall Activity &#9733;" computedValue={computedActivity} value={form.overall_activity} isOverride={form.overrideActivity}
+            onOverride={v => setForm(f => ({ ...f, overrideActivity: true, overall_activity: v }))}
+            onReset={() => setForm(f => ({ ...f, overrideActivity: false, overall_activity: '' }))}
+            colorFn={activityColor} />
         </div>
 
         <SectionLabel>Unrefreshing Sleep?</SectionLabel>
@@ -75,7 +108,10 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
         )}
 
         <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--acc-d)', borderRadius: 8, border: '1px solid rgba(96,165,250,0.2)' }}>
-          <SymptomRow label="Overall Symptom &#9733;" data={form.overall_symptom} onChange={(sub, v) => setN('overall_symptom', sub, v)} highlight />
+          <AutoSymptomRow label="Overall Symptom &#9733;" computedData={{ am: computedSymptomAm, mid: computedSymptomMid, pm: computedSymptomPm }}
+            data={form.overall_symptom} isOverride={form.overrideSymptom}
+            onOverride={(sub, v) => setForm(f => ({ ...f, overrideSymptom: true, overall_symptom: { ...f.overall_symptom, [sub]: v } }))}
+            onReset={() => setForm(f => ({ ...f, overrideSymptom: false, overall_symptom: { am: '', mid: '', pm: '' } }))} />
         </div>
 
         <SectionLabel>Crash?</SectionLabel>
@@ -101,7 +137,7 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
 
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 20 }}>
           <BtnS onClick={onCancel}>Cancel</BtnS>
-          <BtnP onClick={() => onSave(form)}>Save</BtnP>
+          <BtnP onClick={handleSave}>Save</BtnP>
         </div>
 
         {onDelete && (

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -125,8 +125,8 @@ function formatCalc(v) {
 function ResetLink({ onClick }) {
   return (
     <button onClick={e => { e.stopPropagation(); onClick(); }} aria-label="Reset to calculated average" style={{
-      background: 'none', border: 'none', padding: 0, fontSize: 10, color: 'var(--acc)',
-      cursor: 'pointer', fontFamily: 'var(--font)', textDecoration: 'underline',
+      background: 'none', border: 'none', padding: 0, fontSize: 12, color: 'var(--org)',
+      cursor: 'pointer', fontFamily: 'var(--font)', textDecoration: 'underline', fontWeight: 600,
     }}>reset</button>
   );
 }
@@ -166,7 +166,7 @@ export function AutoScoreInput({ label, computedValue, value, isOverride, onOver
       </div>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 36, borderRadius: 6, background: 'rgba(96,165,250,0.08)' }}>
         <span style={{ fontSize: 20, fontWeight: 700, fontFamily: 'var(--mono)', color: display !== null ? colorFn(display) : 'var(--tx-d)' }}>
-          {display !== null ? display : '\u2014'}
+          {display !== null ? display : '—'}
         </span>
       </div>
       {display !== null && <div style={{ fontSize: 9, color: 'var(--tx-d)', marginTop: 4, textAlign: 'center' }}>tap to override</div>}
@@ -183,12 +183,15 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
           <ResetLink onClick={onReset} />
         </div>
         <div style={{ display: 'flex', gap: 8, flex: 1 }}>
-          {['am', 'mid', 'pm'].map((p, idx) => (
+          {['am', 'mid', 'pm'].map((p, idx) => {
+            const raw = data[p];
+            const safeVal = (raw === '' || raw == null || (!isNaN(Number(raw)) && String(raw).trim() !== '')) ? (raw ?? '') : '';
+            return (
             <div key={p} style={{ flex: 1, textAlign: 'center' }}>
               <div style={{ fontSize: 10, color: 'var(--tx-d)', marginBottom: 4 }}>{['AM', 'Mid', 'PM'][idx]}</div>
               <input
-                type="number" min="0" max="10" placeholder="\u2014"
-                value={data[p]}
+                type="number" min="0" max="10" placeholder="—"
+                value={safeVal}
                 onChange={(e) => {
                   const val = e.target.value;
                   if (val === '') { onOverride(p, val); return; }
@@ -199,7 +202,8 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
                 style={{ ...s.input, textAlign: 'center', padding: '8px 4px', fontSize: 14, fontWeight: 600, color: symptomColor(data[p]), minHeight: 40 }}
               />
             </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     );
@@ -234,7 +238,7 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
                 color: display !== null ? symptomColor(display) : 'var(--tx-d)',
                 background: 'rgba(96,165,250,0.08)', borderStyle: 'dashed',
               }}>
-                {display !== null ? display : '\u2014'}
+                {display !== null ? display : '—'}
               </div>
             </div>
           );

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -179,8 +179,8 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid rgba(42,51,64,0.3)' }} role="group" aria-label={`${label} symptom scores`}>
         <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
-          <span>{label} <span style={{ color: 'var(--org)' }}>*</span></span>
-          <ResetLink onClick={onReset} />
+          <span>{label}</span>
+          <span><span style={{ color: 'var(--org)' }}>*</span> <ResetLink onClick={onReset} /></span>
         </div>
         <div style={{ display: 'flex', gap: 8, flex: 1 }}>
           {['am', 'mid', 'pm'].map((p, idx) => {

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -227,22 +227,25 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
       <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4 }}>
         {label} <span style={{ fontSize: 9, color: 'var(--tx-d)', fontWeight: 400 }}>avg</span>
       </div>
-      <div style={{ display: 'flex', gap: 8, flex: 1 }}>
-        {['am', 'mid', 'pm'].map((p, idx) => {
-          const display = formatCalc(computedData[p]);
-          return (
-            <div key={p} style={{ flex: 1, textAlign: 'center' }}>
-              <div style={{ fontSize: 10, color: 'var(--tx-d)', marginBottom: 4 }}>{['AM', 'Mid', 'PM'][idx]}</div>
-              <div style={{
-                ...s.input, textAlign: 'center', padding: '8px 4px', fontSize: 14, fontWeight: 600, minHeight: 40,
-                color: display !== null ? symptomColor(display) : 'var(--tx-d)',
-                background: 'rgba(96,165,250,0.08)', borderStyle: 'dashed',
-              }}>
-                {display !== null ? display : '—'}
+      <div style={{ display: 'flex', gap: 8, flex: 1, flexDirection: 'column' }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {['am', 'mid', 'pm'].map((p, idx) => {
+            const display = formatCalc(computedData[p]);
+            return (
+              <div key={p} style={{ flex: 1, textAlign: 'center' }}>
+                <div style={{ fontSize: 10, color: 'var(--tx-d)', marginBottom: 4 }}>{['AM', 'Mid', 'PM'][idx]}</div>
+                <div style={{
+                  ...s.input, textAlign: 'center', padding: '8px 4px', fontSize: 14, fontWeight: 600, minHeight: 40,
+                  color: display !== null ? symptomColor(display) : 'var(--tx-d)',
+                  background: 'rgba(96,165,250,0.08)', borderStyle: 'dashed',
+                }}>
+                  {display !== null ? display : '—'}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
+        {hasAnyComputed && <div style={{ fontSize: 13, color: 'var(--tx-d)', textAlign: 'center', cursor: 'pointer', padding: '2px 0' }}>tap to override</div>}
       </div>
     </div>
   );

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -118,6 +118,132 @@ export function SymptomRow({ label, data, onChange, highlight }) {
   );
 }
 
+function formatCalc(v) {
+  return v !== null ? (Math.round(v * 10) / 10).toFixed(1) : null;
+}
+
+function ResetLink({ onClick }) {
+  return (
+    <button onClick={e => { e.stopPropagation(); onClick(); }} aria-label="Reset to calculated average" style={{
+      background: 'none', border: 'none', padding: 0, fontSize: 10, color: 'var(--acc)',
+      cursor: 'pointer', fontFamily: 'var(--font)', textDecoration: 'underline',
+    }}>reset</button>
+  );
+}
+
+export function AutoScoreInput({ label, computedValue, value, isOverride, onOverride, onReset, colorFn }) {
+  const display = formatCalc(computedValue);
+
+  if (isOverride) {
+    return (
+      <div role="group" aria-label={`${label} score`} style={{ background: 'var(--acc-d)', borderRadius: 8, padding: '8px 10px', border: '1px solid rgba(96,165,250,0.2)' }}>
+        <div style={{ fontSize: 11, color: 'var(--acc)', marginBottom: 6, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+          {label} <span style={{ color: 'var(--org)' }}>*</span> <ResetLink onClick={onReset} />
+        </div>
+        <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }} role="radiogroup" aria-label={`${label} score selector`}>
+          {[...Array(11)].map((_, i) => {
+            const sel = String(i) === String(value);
+            return (
+              <button key={i} onClick={() => onOverride(String(i))} role="radio" aria-checked={sel} aria-label={`${i}`} style={{
+                width: 30, height: 36, borderRadius: 6, border: 'none', cursor: 'pointer',
+                fontSize: 13, fontWeight: 600, fontFamily: 'var(--mono)',
+                background: sel ? colorFn(i) : 'var(--card)',
+                color: sel ? '#000' : 'var(--tx-d)',
+                minHeight: 36, transition: 'all 0.15s',
+              }}>{i}</button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div role="group" aria-label={`${label} score (auto-calculated)`} onClick={() => { if (display !== null) onOverride(String(Math.round(computedValue))); }}
+      style={{ background: 'var(--acc-d)', borderRadius: 8, padding: '8px 10px', border: '1px solid rgba(96,165,250,0.2)', cursor: display !== null ? 'pointer' : 'default' }}>
+      <div style={{ fontSize: 11, color: 'var(--acc)', marginBottom: 6, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 4 }}>
+        {label} <span style={{ fontSize: 9, color: 'var(--tx-d)', fontWeight: 400 }}>avg</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: 36, borderRadius: 6, background: 'rgba(96,165,250,0.08)' }}>
+        <span style={{ fontSize: 20, fontWeight: 700, fontFamily: 'var(--mono)', color: display !== null ? colorFn(display) : 'var(--tx-d)' }}>
+          {display !== null ? display : '\u2014'}
+        </span>
+      </div>
+      {display !== null && <div style={{ fontSize: 9, color: 'var(--tx-d)', marginTop: 4, textAlign: 'center' }}>tap to override</div>}
+    </div>
+  );
+}
+
+export function AutoSymptomRow({ label, computedData, data, isOverride, onOverride, onReset }) {
+  if (isOverride) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid rgba(42,51,64,0.3)' }} role="group" aria-label={`${label} symptom scores`}>
+        <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4 }}>
+          {label} <span style={{ color: 'var(--org)' }}>*</span>
+          <ResetLink onClick={onReset} />
+        </div>
+        <div style={{ display: 'flex', gap: 8, flex: 1 }}>
+          {['am', 'mid', 'pm'].map((p, idx) => (
+            <div key={p} style={{ flex: 1, textAlign: 'center' }}>
+              <div style={{ fontSize: 10, color: 'var(--tx-d)', marginBottom: 4 }}>{['AM', 'Mid', 'PM'][idx]}</div>
+              <input
+                type="number" min="0" max="10" placeholder="\u2014"
+                value={data[p]}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  if (val === '') { onOverride(p, val); return; }
+                  const n = Number(val);
+                  if (!isNaN(n) && n >= 0 && n <= 10) onOverride(p, val);
+                }}
+                aria-label={`${label} ${['AM', 'Midday', 'PM'][idx]} score`}
+                style={{ ...s.input, textAlign: 'center', padding: '8px 4px', fontSize: 14, fontWeight: 600, color: symptomColor(data[p]), minHeight: 40 }}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const hasAnyComputed = computedData.am !== null || computedData.mid !== null || computedData.pm !== null;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid rgba(42,51,64,0.3)', cursor: hasAnyComputed ? 'pointer' : 'default' }}
+      role="group" aria-label={`${label} symptom scores (auto-calculated)`}
+      onClick={() => {
+        if (hasAnyComputed) {
+          const initAm = formatCalc(computedData.am) || '';
+          const initMid = formatCalc(computedData.mid) || '';
+          const initPm = formatCalc(computedData.pm) || '';
+          onOverride('am', initAm);
+          onOverride('mid', initMid);
+          onOverride('pm', initPm);
+        }
+      }}>
+      <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4 }}>
+        {label} <span style={{ fontSize: 9, color: 'var(--tx-d)', fontWeight: 400 }}>avg</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8, flex: 1 }}>
+        {['am', 'mid', 'pm'].map((p, idx) => {
+          const display = formatCalc(computedData[p]);
+          return (
+            <div key={p} style={{ flex: 1, textAlign: 'center' }}>
+              <div style={{ fontSize: 10, color: 'var(--tx-d)', marginBottom: 4 }}>{['AM', 'Mid', 'PM'][idx]}</div>
+              <div style={{
+                ...s.input, textAlign: 'center', padding: '8px 4px', fontSize: 14, fontWeight: 600, minHeight: 40,
+                color: display !== null ? symptomColor(display) : 'var(--tx-d)',
+                background: 'rgba(96,165,250,0.08)', borderStyle: 'dashed',
+              }}>
+                {display !== null ? display : '\u2014'}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function Sparkline({ data, color, height = 48 }) {
   if (!data || data.length < 2) return null;
   const clean = data.filter(v => !isNaN(v));

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -169,7 +169,7 @@ export function AutoScoreInput({ label, computedValue, value, isOverride, onOver
           {display !== null ? display : '—'}
         </span>
       </div>
-      {display !== null && <div style={{ fontSize: 9, color: 'var(--tx-d)', marginTop: 4, textAlign: 'center' }}>tap to override</div>}
+      {display !== null && <div style={{ fontSize: 13, color: 'var(--tx-d)', marginTop: 4, textAlign: 'center', cursor: 'pointer', padding: '2px 0' }}>tap to override</div>}
     </div>
   );
 }

--- a/src/components.jsx
+++ b/src/components.jsx
@@ -137,8 +137,8 @@ export function AutoScoreInput({ label, computedValue, value, isOverride, onOver
   if (isOverride) {
     return (
       <div role="group" aria-label={`${label} score`} style={{ background: 'var(--acc-d)', borderRadius: 8, padding: '8px 10px', border: '1px solid rgba(96,165,250,0.2)' }}>
-        <div style={{ fontSize: 11, color: 'var(--acc)', marginBottom: 6, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
-          {label} <span style={{ color: 'var(--org)' }}>*</span> <ResetLink onClick={onReset} />
+        <div style={{ fontSize: 11, color: 'var(--acc)', marginBottom: 6, fontWeight: 600 }}>
+          <span>{label} <span style={{ color: 'var(--org)' }}>*</span></span>{' '}<ResetLink onClick={onReset} />
         </div>
         <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }} role="radiogroup" aria-label={`${label} score selector`}>
           {[...Array(11)].map((_, i) => {
@@ -178,8 +178,8 @@ export function AutoSymptomRow({ label, computedData, data, isOverride, onOverri
   if (isOverride) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid rgba(42,51,64,0.3)' }} role="group" aria-label={`${label} symptom scores`}>
-        <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', alignItems: 'center', gap: 4 }}>
-          {label} <span style={{ color: 'var(--org)' }}>*</span>
+        <div style={{ width: 85, fontSize: 13, color: 'var(--acc)', fontWeight: 600, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
+          <span>{label} <span style={{ color: 'var(--org)' }}>*</span></span>
           <ResetLink onClick={onReset} />
         </div>
         <div style={{ display: 'flex', gap: 8, flex: 1 }}>

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,11 +53,33 @@ export function avgField(f) {
   return vals.length > 0 ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
 }
 
+export function calcOverallActivity(form) {
+  const vals = [form.physical, form.mental, form.emotional]
+    .filter(x => x !== '' && x !== undefined && x !== null)
+    .map(Number)
+    .filter(x => !isNaN(x));
+  return vals.length > 0 ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
+}
+
+export function calcOverallSymptom(form, period) {
+  const fields = [form.fatigue, form.pain, form.nausea_gi, form.brain_fog];
+  if (form.other_symptom && form.other_symptom.name) {
+    fields.push(form.other_symptom);
+  }
+  const vals = fields
+    .map(f => f && f[period])
+    .filter(x => x !== '' && x !== undefined && x !== null)
+    .map(Number)
+    .filter(x => !isNaN(x));
+  return vals.length > 0 ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
+}
+
 export function emptyDay(date) {
   return {
     id: `day-${date}`,
     date,
     physical: '', mental: '', emotional: '', overall_activity: '',
+    overrideActivity: false, overrideSymptom: false,
     unrefreshing_sleep: null,
     fatigue: { am: '', mid: '', pm: '' },
     pain: { am: '', mid: '', pm: '' },

--- a/tests/e2e/features.test.js
+++ b/tests/e2e/features.test.js
@@ -247,3 +247,162 @@ test.describe('Plan View - Accessibility', () => {
     expect(expanded).toBe('true');
   });
 });
+
+// Helper: open day editor for today
+async function openDayEditor(page) {
+  await completeOnboarding(page);
+  await page.getByRole('button', { name: 'Log today\'s entry' }).click();
+  await page.waitForTimeout(500);
+}
+
+// Helper: select a score from a ScoreInput radio group
+async function selectScore(page, groupLabel, value) {
+  const group = page.locator(`[aria-label="${groupLabel} score selector"]`);
+  await group.getByRole('radio', { name: String(value), exact: true }).click();
+}
+
+test.describe('Auto-Calculate Overall Activity', () => {
+  test('auto-calculates average of activity scores', async ({ page }) => {
+    await openDayEditor(page);
+    await selectScore(page, 'Physical', 2);
+    await selectScore(page, 'Mental', 4);
+    await selectScore(page, 'Emotional', 6);
+    await page.waitForTimeout(300);
+    // Overall Activity auto-calculated group should show "4.0"
+    const autoGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await expect(autoGroup.getByText('4.0')).toBeVisible({ timeout: 2000 });
+    await expect(autoGroup.getByText('tap to override')).toBeVisible();
+  });
+
+  test('shows em-dash when no activity data', async ({ page }) => {
+    await openDayEditor(page);
+    const autoGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await expect(autoGroup.getByText('—')).toBeVisible({ timeout: 2000 });
+    await expect(autoGroup.getByText('tap to override')).not.toBeVisible();
+  });
+
+  test('tap to override enters override mode', async ({ page }) => {
+    await openDayEditor(page);
+    await selectScore(page, 'Physical', 2);
+    await selectScore(page, 'Mental', 4);
+    await selectScore(page, 'Emotional', 6);
+    await page.waitForTimeout(300);
+    // Click the auto-calculated area to enter override
+    const autoGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await autoGroup.click();
+    await page.waitForTimeout(300);
+    // Should now show override mode with reset button and radio buttons
+    const overrideGroup = page.locator('[aria-label="Overall Activity ★ score"]');
+    await expect(overrideGroup).toBeVisible({ timeout: 2000 });
+    await expect(overrideGroup.getByLabel('Reset to calculated average')).toBeVisible();
+    // Radio button for the rounded value (4) should be checked
+    const radio4 = overrideGroup.getByRole('radio', { name: '4', exact: true });
+    await expect(radio4).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('reset returns to auto-calculated state', async ({ page }) => {
+    await openDayEditor(page);
+    await selectScore(page, 'Physical', 2);
+    await selectScore(page, 'Mental', 4);
+    await selectScore(page, 'Emotional', 6);
+    await page.waitForTimeout(300);
+    // Enter override mode
+    const autoGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await autoGroup.click();
+    await page.waitForTimeout(300);
+    // Select a different value (9)
+    const overrideGroup = page.locator('[aria-label="Overall Activity ★ score"]');
+    await overrideGroup.getByRole('radio', { name: '9', exact: true }).click();
+    // Click reset
+    await overrideGroup.getByLabel('Reset to calculated average').click();
+    await page.waitForTimeout(300);
+    // Should return to auto-calculated showing 4.0
+    const restoredGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await expect(restoredGroup.getByText('4.0')).toBeVisible({ timeout: 2000 });
+    await expect(restoredGroup.getByText('avg')).toBeVisible();
+  });
+});
+
+test.describe('Auto-Calculate Overall Symptom', () => {
+  test('auto-calculates symptom averages per period', async ({ page }) => {
+    await openDayEditor(page);
+    // Fill Fatigue AM=4, Pain AM=6
+    await page.getByLabel('Fatigue AM score').fill('4');
+    await page.getByLabel('Pain AM score').fill('6');
+    await page.waitForTimeout(300);
+    // Overall Symptom auto-calculated group should show AM=5.0
+    const autoGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores (auto-calculated)"]');
+    await expect(autoGroup.getByText('5.0')).toBeVisible({ timeout: 2000 });
+    // PM should show em-dash (no data) — use .first() since Mid also shows —
+    await expect(autoGroup.getByText('—').first()).toBeVisible();
+  });
+
+  test('tap to override enters override mode', async ({ page }) => {
+    await openDayEditor(page);
+    await page.getByLabel('Fatigue AM score').fill('4');
+    await page.getByLabel('Pain AM score').fill('6');
+    await page.waitForTimeout(300);
+    // Click the auto-calculated row
+    const autoGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores (auto-calculated)"]');
+    await autoGroup.click();
+    await page.waitForTimeout(300);
+    // Should now show override mode with input fields and reset button
+    const overrideGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores"]');
+    await expect(overrideGroup).toBeVisible({ timeout: 2000 });
+    await expect(overrideGroup.getByLabel('Reset to calculated average')).toBeVisible();
+    // AM input should have the calculated value
+    const amInput = overrideGroup.getByLabel('Overall Symptom ★ AM score');
+    await expect(amInput).toBeVisible();
+    await expect(amInput).toHaveValue('5.0');
+  });
+
+  test('reset returns to auto-calculated state', async ({ page }) => {
+    await openDayEditor(page);
+    await page.getByLabel('Fatigue AM score').fill('4');
+    await page.getByLabel('Pain AM score').fill('6');
+    await page.waitForTimeout(300);
+    // Enter override mode
+    const autoGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores (auto-calculated)"]');
+    await autoGroup.click();
+    await page.waitForTimeout(300);
+    // Change AM value
+    const overrideGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores"]');
+    const amInput = overrideGroup.getByLabel('Overall Symptom ★ AM score');
+    await amInput.fill('9');
+    // Click reset
+    await overrideGroup.getByLabel('Reset to calculated average').click();
+    await page.waitForTimeout(300);
+    // Should return to auto-calculated with avg label
+    const restoredGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores (auto-calculated)"]');
+    await expect(restoredGroup).toBeVisible({ timeout: 2000 });
+    await expect(restoredGroup.getByText('5.0')).toBeVisible();
+  });
+});
+
+test.describe('Auto-Calculate Save & Reload', () => {
+  test('auto-calculated values persist after save and re-open', async ({ page }) => {
+    await openDayEditor(page);
+    // Fill activity scores: avg = (3+6+9)/3 = 6
+    await selectScore(page, 'Physical', 3);
+    await selectScore(page, 'Mental', 6);
+    await selectScore(page, 'Emotional', 9);
+    // Fill a symptom: Fatigue AM=8
+    await page.getByLabel('Fatigue AM score').fill('8');
+    await page.waitForTimeout(300);
+    // Save
+    await page.getByText('Save').first().click();
+    await page.waitForTimeout(500);
+    // Re-open the saved entry
+    await page.getByRole('button', { name: "Edit today's entry" }).click();
+    await page.waitForTimeout(500);
+    // Entry re-opens in auto-calculated mode (overrideActivity: false is preserved)
+    // Overall Activity should show 6.0 (computed from saved scores)
+    const actGroup = page.locator('[aria-label="Overall Activity ★ score (auto-calculated)"]');
+    await expect(actGroup).toBeVisible({ timeout: 2000 });
+    await expect(actGroup.getByText('6.0')).toBeVisible();
+    // Overall Symptom AM should show 8.0 (computed from saved Fatigue AM=8)
+    const symGroup = page.locator('[aria-label="Overall Symptom ★ symptom scores (auto-calculated)"]');
+    await expect(symGroup).toBeVisible({ timeout: 2000 });
+    await expect(symGroup.getByText('8.0')).toBeVisible();
+  });
+});

--- a/tests/unit/utils-new.test.js
+++ b/tests/unit/utils-new.test.js
@@ -337,15 +337,17 @@ describe('getLast30Dates', () => {
 
   it('ends with today', () => {
     const dates = getLast30Dates();
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
     expect(dates[29]).toBe(today);
   });
 
   it('starts 29 days ago', () => {
     const dates = getLast30Dates();
-    const expected = new Date();
-    expected.setDate(expected.getDate() - 29);
-    expect(dates[0]).toBe(expected.toISOString().split('T')[0]);
+    const d = new Date();
+    d.setDate(d.getDate() - 29);
+    const expected = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    expect(dates[0]).toBe(expected);
   });
 
   it('dates are in ascending chronological order', () => {
@@ -358,10 +360,11 @@ describe('getLast30Dates', () => {
   it('has consecutive dates with no gaps', () => {
     const dates = getLast30Dates();
     for (let i = 1; i < dates.length; i++) {
+      // Advance previous date by 1 day using local time to avoid DST drift
       const prev = new Date(dates[i - 1] + 'T12:00:00');
-      const curr = new Date(dates[i] + 'T12:00:00');
-      const diff = (curr - prev) / (1000 * 60 * 60 * 24);
-      expect(diff).toBe(1);
+      prev.setDate(prev.getDate() + 1);
+      const expected = `${prev.getFullYear()}-${String(prev.getMonth()+1).padStart(2,'0')}-${String(prev.getDate()).padStart(2,'0')}`;
+      expect(dates[i]).toBe(expected);
     }
   });
 });

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -8,6 +8,8 @@ import {
   avgField,
   emptyDay,
   generateExportText,
+  calcOverallActivity,
+  calcOverallSymptom,
 } from '../../src/utils.js';
 
 describe('getDateStr', () => {
@@ -176,6 +178,12 @@ describe('emptyDay', () => {
     expect(day.crash).toBeNull();
     expect(day.unrefreshing_sleep).toBeNull();
   });
+
+  it('has false override flags', () => {
+    const day = emptyDay('2024-01-15');
+    expect(day.overrideActivity).toBe(false);
+    expect(day.overrideSymptom).toBe(false);
+  });
 });
 
 describe('generateExportText', () => {
@@ -222,5 +230,91 @@ describe('generateExportText', () => {
   it('omits plan section when plan is empty', () => {
     const text = generateExportText([], { causes: [], barriers: [], strategies: [] });
     expect(text).not.toContain('=== MY CRASH AVOIDANCE PLAN ===');
+  });
+});
+
+describe('calcOverallActivity', () => {
+  it('returns the average of physical, mental, emotional', () => {
+    expect(calcOverallActivity({ physical: '2', mental: '4', emotional: '6' })).toBe(4);
+  });
+
+  it('ignores empty string values', () => {
+    expect(calcOverallActivity({ physical: '3', mental: '', emotional: '5' })).toBe(4);
+  });
+
+  it('returns null when all values are empty', () => {
+    expect(calcOverallActivity({ physical: '', mental: '', emotional: '' })).toBeNull();
+  });
+
+  it('handles string number values', () => {
+    expect(calcOverallActivity({ physical: '10', mental: '0', emotional: '5' })).toBe(5);
+  });
+
+  it('returns the value when only one field is filled', () => {
+    expect(calcOverallActivity({ physical: '7', mental: '', emotional: '' })).toBe(7);
+  });
+
+  it('ignores null and undefined values', () => {
+    expect(calcOverallActivity({ physical: null, mental: undefined, emotional: '6' })).toBe(6);
+  });
+});
+
+describe('calcOverallSymptom', () => {
+  const baseForm = {
+    fatigue: { am: '2', mid: '4', pm: '6' },
+    pain: { am: '4', mid: '6', pm: '8' },
+    nausea_gi: { am: '1', mid: '3', pm: '5' },
+    brain_fog: { am: '3', mid: '5', pm: '7' },
+    other_symptom: { name: '', am: '', mid: '', pm: '' },
+  };
+
+  it('averages symptom fields for am period', () => {
+    expect(calcOverallSymptom(baseForm, 'am')).toBe(2.5);
+  });
+
+  it('averages symptom fields for mid period', () => {
+    expect(calcOverallSymptom(baseForm, 'mid')).toBe(4.5);
+  });
+
+  it('averages symptom fields for pm period', () => {
+    expect(calcOverallSymptom(baseForm, 'pm')).toBe(6.5);
+  });
+
+  it('includes other_symptom when name is non-empty', () => {
+    const form = {
+      ...baseForm,
+      other_symptom: { name: 'dizziness', am: '10', mid: '10', pm: '10' },
+    };
+    expect(calcOverallSymptom(form, 'am')).toBe(4);
+  });
+
+  it('excludes other_symptom when name is empty', () => {
+    const form = {
+      ...baseForm,
+      other_symptom: { name: '', am: '10', mid: '10', pm: '10' },
+    };
+    expect(calcOverallSymptom(form, 'am')).toBe(2.5);
+  });
+
+  it('ignores empty string values', () => {
+    const form = {
+      fatigue: { am: '4', mid: '', pm: '' },
+      pain: { am: '', mid: '', pm: '' },
+      nausea_gi: { am: '6', mid: '', pm: '' },
+      brain_fog: { am: '', mid: '', pm: '' },
+      other_symptom: { name: '', am: '', mid: '', pm: '' },
+    };
+    expect(calcOverallSymptom(form, 'am')).toBe(5);
+  });
+
+  it('returns null when all values for a period are empty', () => {
+    const form = {
+      fatigue: { am: '', mid: '', pm: '' },
+      pain: { am: '', mid: '', pm: '' },
+      nausea_gi: { am: '', mid: '', pm: '' },
+      brain_fog: { am: '', mid: '', pm: '' },
+      other_symptom: { name: '', am: '', mid: '', pm: '' },
+    };
+    expect(calcOverallSymptom(form, 'am')).toBeNull();
   });
 });

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -16,7 +16,8 @@ describe('getDateStr', () => {
   it('returns today in YYYY-MM-DD format', () => {
     const result = getDateStr();
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}-${String(now.getDate()).padStart(2,'0')}`;
     expect(result).toBe(today);
   });
 
@@ -24,14 +25,16 @@ describe('getDateStr', () => {
     const result = getDateStr(-1);
     const d = new Date();
     d.setDate(d.getDate() - 1);
-    expect(result).toBe(d.toISOString().split('T')[0]);
+    const expected = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    expect(result).toBe(expected);
   });
 
   it('returns tomorrow when offset is 1', () => {
     const result = getDateStr(1);
     const d = new Date();
     d.setDate(d.getDate() + 1);
-    expect(result).toBe(d.toISOString().split('T')[0]);
+    const expected = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+    expect(result).toBe(expected);
   });
 });
 


### PR DESCRIPTION
Overall Activity now auto-calculates as the average of physical, mental,
and emotional scores. Overall Symptom auto-calculates per AM/Mid/PM as
the average of fatigue, pain, nausea/GI, brain fog (and custom symptom
if named). Users can tap to override with a manual value and reset back
to the calculated average.

Closes #17

https://claude.ai/code/session_01VEJJ9mB5XmkUGtcMnhxCGD