### PR TITLE
Add Quick Log mode and Learn section PEM definition (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ A progressive web app for tracking post-exertional malaise, based on the [Open M
 ## Features
 
 ### Daily Tracking
+- **Quick Log / Full Log modes** — Quick Log captures overall activity, overall symptoms, crash, and sleep in seconds; Full Log adds per-dimension activity and time-of-day symptom tracking
 - **Track** daily activity levels (physical, mental, emotional) on the OMF 0-10 scale
+- **Auto-calculated overall scores** — overall activity and overall symptom scores are computed from individual fields, with tap-to-override for manual entry
 - **Log symptoms** (fatigue, pain, nausea/GI, brain fog, plus a custom "other" symptom) three times daily (AM, midday, PM)
 - **Mark crashes** and add comments about what happened
 - **Delete entries** to correct mistakes or remove test data
@@ -22,9 +24,14 @@ A progressive web app for tracking post-exertional malaise, based on the [Open M
 ### Planning & Export
 - **Crash Avoidance Plan** builder using the full OMF causes, barriers, and strategies checklists
 - **Export** tracking data and your plan as formatted text to share with doctors or support team
-- **CSV export** — download tracking data as a spreadsheet-ready CSV file
+- **CSV export** — download tracking data as a spreadsheet-ready CSV file, including entry mode and override indicators
 - **Backup & restore** — JSON export/import so you never lose your data
 - **Print-friendly report** — clean browser print layout for doctor visits
+
+### Learn
+- **Understanding PEM** — educational section differentiating PEM from dysautonomia, MCAS, fibromyalgia, and DOMS
+- **Connection to tracking** — explains how crash logging and pre-crash lookback relate to PEM identification
+- **Quick Log vs Full Log guide** — helps users choose the right logging mode
 
 ### Usability
 - **Onboarding tour** — 4-step guided walkthrough for new users

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
-import { dbGet, dbSet, dbExportAll, dbImportAll } from './db.js';
+import { dbGet, dbSet, dbExportAll, dbImportAll, migrateData } from './db.js';
 import { emptyDay, generateExportText, generateCSV, getDateStr } from './utils.js';
 
 const TrackView = lazy(() => import('./TrackView.jsx'));
@@ -50,10 +50,15 @@ export default function App() {
   useEffect(() => {
     dbGet(DB_KEY).then(stored => {
       if (stored) {
-        setData({ days: stored.days || [], plan: stored.plan || defaultData().plan });
-        setOnboarded(stored.onboarded || false);
-        setTheme(stored.theme || 'dark');
-        if (stored.tourCompleted) setTourStep(null);
+        const migrated = migrateData(stored);
+        setData({ days: migrated.days || [], plan: migrated.plan || defaultData().plan });
+        setOnboarded(migrated.onboarded || false);
+        setTheme(migrated.theme || 'dark');
+        if (migrated.tourCompleted) setTourStep(null);
+        // Persist migrated data if schema version changed
+        if (migrated.schemaVersion !== stored.schemaVersion) {
+          dbSet(DB_KEY, migrated);
+        }
       } else {
         setData(defaultData());
       }

--- a/src/DayEditor.jsx
+++ b/src/DayEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { formatDate, activityColor, symptomColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
+import { formatDate, activityColor, symptomColor, calcOverallActivity, calcOverallSymptom, hasGranularData } from './utils.js';
 import { SectionLabel, ScoreInput, SymptomRow, AutoScoreInput, AutoSymptomRow, BtnP, BtnS, s } from './components.jsx';
 
 function trapFocus(e, containerRef) {
@@ -11,15 +11,6 @@ function trapFocus(e, containerRef) {
   else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
 }
 
-function hasGranularData(form) {
-  if (form.physical !== '' || form.mental !== '' || form.emotional !== '') return true;
-  for (const field of ['fatigue', 'pain', 'nausea_gi', 'brain_fog']) {
-    const f = form[field];
-    if (f && (f.am !== '' || f.mid !== '' || f.pm !== '')) return true;
-  }
-  if (form.other_symptom && form.other_symptom.name) return true;
-  return false;
-}
 
 function ToggleGroup({ label, options, value, onChange }) {
   return (
@@ -45,15 +36,9 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
     // Restore properties that JSON stringify removes (undefined → missing)
     if (!clone.other_symptom) clone.other_symptom = { name: '', am: '', mid: '', pm: '' };
     if (!clone.nausea_gi) clone.nausea_gi = { am: '', mid: '', pm: '' };
-    // Backward compat: existing days without override fields
-    if (clone.overrideActivity === undefined) {
-      clone.overrideActivity = clone.overall_activity !== '' && clone.overall_activity != null;
-    }
-    if (clone.overrideSymptom === undefined) {
-      const os = clone.overall_symptom || { am: '', mid: '', pm: '' };
-      clone.overrideSymptom = os.am !== '' || os.mid !== '' || os.pm !== '';
-    }
-    // Backward compat: existing days without entryMode
+    // Defensive fallbacks (migration in db.js normally guarantees these exist)
+    clone.overrideActivity = clone.overrideActivity ?? false;
+    clone.overrideSymptom = clone.overrideSymptom ?? false;
     if (!clone.entryMode) clone.entryMode = 'full';
     return clone;
   });

--- a/src/DayEditor.jsx
+++ b/src/DayEditor.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { formatDate, activityColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
+import { formatDate, activityColor, symptomColor, calcOverallActivity, calcOverallSymptom } from './utils.js';
 import { SectionLabel, ScoreInput, SymptomRow, AutoScoreInput, AutoSymptomRow, BtnP, BtnS, s } from './components.jsx';
 
 function trapFocus(e, containerRef) {
@@ -9,6 +9,33 @@ function trapFocus(e, containerRef) {
   const first = focusable[0], last = focusable[focusable.length - 1];
   if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
   else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+}
+
+function hasGranularData(form) {
+  if (form.physical !== '' || form.mental !== '' || form.emotional !== '') return true;
+  for (const field of ['fatigue', 'pain', 'nausea_gi', 'brain_fog']) {
+    const f = form[field];
+    if (f && (f.am !== '' || f.mid !== '' || f.pm !== '')) return true;
+  }
+  if (form.other_symptom && form.other_symptom.name) return true;
+  return false;
+}
+
+function ToggleGroup({ label, options, value, onChange }) {
+  return (
+    <div role="radiogroup" aria-label={label} style={{ display: 'flex', gap: 8 }}>
+      {options.map(opt => (
+        <button key={String(opt.v)} role="radio" aria-checked={value === opt.v} aria-label={opt.l}
+          onClick={() => onChange(opt.v)} style={{
+            flex: 1, borderRadius: 8, padding: '10px 18px', fontSize: 14, fontWeight: 600,
+            minHeight: 44, cursor: 'pointer', border: '1px solid', fontFamily: 'var(--font)',
+            background: value === opt.v ? opt.bg : 'var(--card)',
+            color: value === opt.v ? opt.fg : 'var(--tx-m)',
+            borderColor: value === opt.v ? opt.border : 'var(--border)',
+          }}>{opt.l}</button>
+      ))}
+    </div>
+  );
 }
 
 export default function DayEditor({ day, onSave, onCancel, onDelete }) {
@@ -26,10 +53,16 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
       const os = clone.overall_symptom || { am: '', mid: '', pm: '' };
       clone.overrideSymptom = os.am !== '' || os.mid !== '' || os.pm !== '';
     }
+    // Backward compat: existing days without entryMode
+    if (!clone.entryMode) clone.entryMode = 'full';
     return clone;
   });
+  const [modeAnnounce, setModeAnnounce] = useState('');
+  const [showComments, setShowComments] = useState(form.entryMode === 'quick' && form.comments !== '');
   const set = (k, v) => setForm(f => ({ ...f, [k]: v }));
   const setN = (k, sub, v) => setForm(f => ({ ...f, [k]: { ...f[k], [sub]: v } }));
+
+  const isQuick = form.entryMode === 'quick';
 
   const computedActivity = calcOverallActivity(form);
   const computedSymptomAm = calcOverallSymptom(form, 'am');
@@ -38,17 +71,35 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
 
   const round1 = v => v !== null ? String(Math.round(v * 10) / 10) : '';
 
+  const switchMode = (newMode) => {
+    if (newMode === form.entryMode) return;
+    if (newMode === 'quick' && hasGranularData(form)) {
+      if (!window.confirm('Switching to Quick Log will hide detailed fields. Your existing data is preserved and will reappear if you switch back to Full Log.')) return;
+    }
+    setForm(f => ({ ...f, entryMode: newMode }));
+    const label = newMode === 'quick' ? 'Switched to Quick Log mode' : 'Switched to Full Log mode';
+    setModeAnnounce(label);
+    setTimeout(() => setModeAnnounce(''), 2000);
+  };
+
   const handleSave = () => {
     const out = { ...form };
-    if (!out.overrideActivity && computedActivity !== null) {
-      out.overall_activity = round1(computedActivity);
-    }
-    if (!out.overrideSymptom) {
-      out.overall_symptom = {
-        am: round1(computedSymptomAm),
-        mid: round1(computedSymptomMid),
-        pm: round1(computedSymptomPm),
-      };
+    if (isQuick) {
+      out.entryMode = 'quick';
+      out.overrideActivity = true;
+      out.overrideSymptom = true;
+    } else {
+      out.entryMode = 'full';
+      if (!out.overrideActivity && computedActivity !== null) {
+        out.overall_activity = round1(computedActivity);
+      }
+      if (!out.overrideSymptom) {
+        out.overall_symptom = {
+          am: round1(computedSymptomAm),
+          mid: round1(computedSymptomMid),
+          pm: round1(computedSymptomPm),
+        };
+      }
     }
     onSave(out);
   };
@@ -65,75 +116,157 @@ export default function DayEditor({ day, onSave, onCancel, onDelete }) {
           </div>
         </div>
 
-        <SectionLabel>Activity Levels (0-10)</SectionLabel>
-        <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = very low/negligible &middot; 10 = activity when fully healthy</div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-          <ScoreInput label="Physical" value={form.physical} onChange={v => set('physical', v)} colorFn={activityColor} />
-          <ScoreInput label="Mental" value={form.mental} onChange={v => set('mental', v)} colorFn={activityColor} />
-          <ScoreInput label="Emotional" value={form.emotional} onChange={v => set('emotional', v)} colorFn={activityColor} />
-          <AutoScoreInput label="Overall Activity &#9733;" computedValue={computedActivity} value={form.overall_activity} isOverride={form.overrideActivity}
-            onOverride={v => setForm(f => ({ ...f, overrideActivity: true, overall_activity: v }))}
-            onReset={() => setForm(f => ({ ...f, overrideActivity: false, overall_activity: '' }))}
-            colorFn={activityColor} />
+        {/* Mode Selector */}
+        <div role="radiogroup" aria-label="Entry mode" style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+          {[
+            { mode: 'quick', label: 'Quick Log' },
+            { mode: 'full', label: 'Full Log' },
+          ].map(opt => {
+            const active = form.entryMode === opt.mode;
+            const Btn = active ? BtnP : BtnS;
+            return (
+              <Btn key={opt.mode} role="radio" aria-checked={active}
+                onClick={() => switchMode(opt.mode)}
+                style={{ flex: 1, textAlign: 'center' }}>
+                {opt.label}
+              </Btn>
+            );
+          })}
         </div>
 
-        <SectionLabel>Unrefreshing Sleep?</SectionLabel>
-        <div style={{ display: 'flex', gap: 8 }}>
-          {[{ v: true, l: 'Yes' }, { v: false, l: 'No' }].map(opt => (
-            <button key={String(opt.v)} onClick={() => set('unrefreshing_sleep', opt.v)} style={{
-              borderRadius: 8, padding: '10px 18px', fontSize: 14, fontWeight: 600, minHeight: 44, cursor: 'pointer',
-              border: '1px solid',
-              background: form.unrefreshing_sleep === opt.v ? (opt.v ? 'var(--red-d)' : 'var(--grn-d)') : 'var(--card)',
-              color: form.unrefreshing_sleep === opt.v ? (opt.v ? 'var(--red)' : 'var(--grn)') : 'var(--tx-m)',
-              borderColor: form.unrefreshing_sleep === opt.v ? (opt.v ? 'rgba(248,113,113,0.3)' : 'rgba(74,222,128,0.3)') : 'var(--border)',
-              fontFamily: 'var(--font)',
-            }}>{opt.l}</button>
-          ))}
+        {/* Screen reader announcement for mode switch */}
+        <div role="status" aria-live="polite" style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap' }}>
+          {modeAnnounce}
         </div>
 
-        <SectionLabel>Symptoms (0-10, AM / Midday / PM)</SectionLabel>
-        <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = no symptom &middot; 10 = worst experienced</div>
-        <SymptomRow label="Fatigue" data={form.fatigue} onChange={(sub, v) => setN('fatigue', sub, v)} />
-        <SymptomRow label="Pain" data={form.pain} onChange={(sub, v) => setN('pain', sub, v)} />
-        <SymptomRow label="Nausea / GI" data={form.nausea_gi} onChange={(sub, v) => setN('nausea_gi', sub, v)} />
-        <SymptomRow label="Brain Fog" data={form.brain_fog} onChange={(sub, v) => setN('brain_fog', sub, v)} />
+        {isQuick ? (
+          /* ========== QUICK LOG MODE ========== */
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <div>
+              <SectionLabel>Overall Activity (0-10)</SectionLabel>
+              <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = very low/negligible &middot; 10 = activity when fully healthy</div>
+              <ScoreInput label="Overall Activity" value={form.overall_activity}
+                onChange={v => setForm(f => ({ ...f, overall_activity: v, overrideActivity: true }))}
+                colorFn={activityColor} highlight />
+            </div>
 
-        <div style={{ marginTop: 10 }}>
-          <div style={{ fontSize: 11, color: 'var(--tx-m)', marginBottom: 4 }}>Other symptom name:</div>
-          <input value={form.other_symptom.name} onChange={e => setN('other_symptom', 'name', e.target.value)}
-            placeholder="e.g. dizziness, anxiety&hellip;" style={{ ...s.input, fontSize: 13 }} />
-        </div>
-        {form.other_symptom.name && (
-          <SymptomRow label={form.other_symptom.name} data={form.other_symptom} onChange={(sub, v) => setN('other_symptom', sub, v)} />
+            <div>
+              <SectionLabel>Overall Symptoms (0-10)</SectionLabel>
+              <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = no symptoms &middot; 10 = worst experienced &middot; Single end-of-day score</div>
+              <ScoreInput label="Overall Symptoms" value={form.overall_symptom?.am || ''}
+                onChange={v => setForm(f => ({ ...f, overrideSymptom: true, overall_symptom: { am: v, mid: '', pm: '' } }))}
+                colorFn={symptomColor} highlight />
+            </div>
+
+            <div>
+              <SectionLabel>Crash?</SectionLabel>
+              <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 8 }}>A significant set-back in daily function</div>
+              <ToggleGroup label="Crash today" options={[
+                { v: true, l: 'Yes \u2014 Crash', bg: 'var(--red-d)', fg: 'var(--red)', border: 'rgba(248,113,113,0.3)' },
+                { v: false, l: 'No', bg: 'var(--grn-d)', fg: 'var(--grn)', border: 'rgba(74,222,128,0.3)' },
+              ]} value={form.crash} onChange={v => set('crash', v)} />
+            </div>
+
+            <div>
+              <SectionLabel>Sleep</SectionLabel>
+              <ToggleGroup label="Sleep quality" options={[
+                { v: false, l: 'Refreshing', bg: 'var(--grn-d)', fg: 'var(--grn)', border: 'rgba(74,222,128,0.3)' },
+                { v: true, l: 'Unrefreshing', bg: 'var(--pur-d)', fg: 'var(--pur)', border: 'rgba(192,132,252,0.3)' },
+              ]} value={form.unrefreshing_sleep} onChange={v => set('unrefreshing_sleep', v)} />
+            </div>
+
+            <div>
+              <button onClick={() => setShowComments(!showComments)}
+                aria-expanded={showComments} aria-controls="quick-comments"
+                style={{
+                  background: 'none', border: 'none', padding: '4px 0', cursor: 'pointer',
+                  fontSize: 12, color: 'var(--tx-m)', fontFamily: 'var(--font)', fontWeight: 600,
+                }}>
+                {showComments ? '\u25BE' : '\u25B8'} Comments (optional)
+              </button>
+              {showComments && (
+                <textarea id="quick-comments" value={form.comments} maxLength={500}
+                  onChange={e => set('comments', e.target.value)}
+                  rows={2} placeholder="A few words about the day\u2026"
+                  aria-label="Comments (optional)"
+                  style={{ ...s.input, resize: 'vertical', fontFamily: 'var(--font)', marginTop: 6 }} />
+              )}
+            </div>
+          </div>
+        ) : (
+          /* ========== FULL LOG MODE ========== */
+          <>
+            <SectionLabel>Activity Levels (0-10)</SectionLabel>
+            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = very low/negligible &middot; 10 = activity when fully healthy</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+              <ScoreInput label="Physical" value={form.physical} onChange={v => set('physical', v)} colorFn={activityColor} />
+              <ScoreInput label="Mental" value={form.mental} onChange={v => set('mental', v)} colorFn={activityColor} />
+              <ScoreInput label="Emotional" value={form.emotional} onChange={v => set('emotional', v)} colorFn={activityColor} />
+              <AutoScoreInput label="Overall Activity &#9733;" computedValue={computedActivity} value={form.overall_activity} isOverride={form.overrideActivity}
+                onOverride={v => setForm(f => ({ ...f, overrideActivity: true, overall_activity: v }))}
+                onReset={() => setForm(f => ({ ...f, overrideActivity: false, overall_activity: '' }))}
+                colorFn={activityColor} />
+            </div>
+
+            <SectionLabel>Unrefreshing Sleep?</SectionLabel>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {[{ v: true, l: 'Yes' }, { v: false, l: 'No' }].map(opt => (
+                <button key={String(opt.v)} onClick={() => set('unrefreshing_sleep', opt.v)} style={{
+                  borderRadius: 8, padding: '10px 18px', fontSize: 14, fontWeight: 600, minHeight: 44, cursor: 'pointer',
+                  border: '1px solid',
+                  background: form.unrefreshing_sleep === opt.v ? (opt.v ? 'var(--red-d)' : 'var(--grn-d)') : 'var(--card)',
+                  color: form.unrefreshing_sleep === opt.v ? (opt.v ? 'var(--red)' : 'var(--grn)') : 'var(--tx-m)',
+                  borderColor: form.unrefreshing_sleep === opt.v ? (opt.v ? 'rgba(248,113,113,0.3)' : 'rgba(74,222,128,0.3)') : 'var(--border)',
+                  fontFamily: 'var(--font)',
+                }}>{opt.l}</button>
+              ))}
+            </div>
+
+            <SectionLabel>Symptoms (0-10, AM / Midday / PM)</SectionLabel>
+            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 10 }}>0 = no symptom &middot; 10 = worst experienced</div>
+            <SymptomRow label="Fatigue" data={form.fatigue} onChange={(sub, v) => setN('fatigue', sub, v)} />
+            <SymptomRow label="Pain" data={form.pain} onChange={(sub, v) => setN('pain', sub, v)} />
+            <SymptomRow label="Nausea / GI" data={form.nausea_gi} onChange={(sub, v) => setN('nausea_gi', sub, v)} />
+            <SymptomRow label="Brain Fog" data={form.brain_fog} onChange={(sub, v) => setN('brain_fog', sub, v)} />
+
+            <div style={{ marginTop: 10 }}>
+              <div style={{ fontSize: 11, color: 'var(--tx-m)', marginBottom: 4 }}>Other symptom name:</div>
+              <input value={form.other_symptom.name} onChange={e => setN('other_symptom', 'name', e.target.value)}
+                placeholder="e.g. dizziness, anxiety&hellip;" style={{ ...s.input, fontSize: 13 }} />
+            </div>
+            {form.other_symptom.name && (
+              <SymptomRow label={form.other_symptom.name} data={form.other_symptom} onChange={(sub, v) => setN('other_symptom', sub, v)} />
+            )}
+
+            <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--acc-d)', borderRadius: 8, border: '1px solid rgba(96,165,250,0.2)' }}>
+              <AutoSymptomRow label="Overall Symptom &#9733;" computedData={{ am: computedSymptomAm, mid: computedSymptomMid, pm: computedSymptomPm }}
+                data={form.overall_symptom} isOverride={form.overrideSymptom}
+                onOverride={(sub, v) => setForm(f => ({ ...f, overrideSymptom: true, overall_symptom: { ...f.overall_symptom, [sub]: v } }))}
+                onReset={() => setForm(f => ({ ...f, overrideSymptom: false, overall_symptom: { am: '', mid: '', pm: '' } }))} />
+            </div>
+
+            <SectionLabel>Crash?</SectionLabel>
+            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 8 }}>A significant set-back in daily function</div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {[{ v: true, l: 'Yes \u2014 Crash' }, { v: false, l: 'No' }].map(opt => (
+                <button key={String(opt.v)} onClick={() => set('crash', opt.v)} style={{
+                  borderRadius: 8, padding: '10px 18px', fontSize: 14, fontWeight: 600, minHeight: 44, cursor: 'pointer',
+                  border: '1px solid', fontFamily: 'var(--font)',
+                  background: form.crash === opt.v ? (opt.v ? 'var(--red-d)' : 'var(--grn-d)') : 'var(--card)',
+                  color: form.crash === opt.v ? (opt.v ? 'var(--red)' : 'var(--grn)') : 'var(--tx-m)',
+                  borderColor: form.crash === opt.v ? (opt.v ? 'rgba(248,113,113,0.3)' : 'rgba(74,222,128,0.3)') : 'var(--border)',
+                }}>{opt.l}</button>
+              ))}
+            </div>
+
+            <SectionLabel>Comments</SectionLabel>
+            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 6 }}>Brief reminder, e.g. &quot;Shopping for 3 hours&quot;</div>
+            <textarea value={form.comments} maxLength={500} onChange={e => set('comments', e.target.value)}
+              rows={3} placeholder="A few words about the day&hellip;"
+              aria-label="Comments about the day"
+              style={{ ...s.input, resize: 'vertical', fontFamily: 'var(--font)' }} />
+          </>
         )}
-
-        <div style={{ marginTop: 6, padding: '8px 10px', background: 'var(--acc-d)', borderRadius: 8, border: '1px solid rgba(96,165,250,0.2)' }}>
-          <AutoSymptomRow label="Overall Symptom &#9733;" computedData={{ am: computedSymptomAm, mid: computedSymptomMid, pm: computedSymptomPm }}
-            data={form.overall_symptom} isOverride={form.overrideSymptom}
-            onOverride={(sub, v) => setForm(f => ({ ...f, overrideSymptom: true, overall_symptom: { ...f.overall_symptom, [sub]: v } }))}
-            onReset={() => setForm(f => ({ ...f, overrideSymptom: false, overall_symptom: { am: '', mid: '', pm: '' } }))} />
-        </div>
-
-        <SectionLabel>Crash?</SectionLabel>
-        <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 8 }}>A significant set-back in daily function</div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          {[{ v: true, l: 'Yes — Crash' }, { v: false, l: 'No' }].map(opt => (
-            <button key={String(opt.v)} onClick={() => set('crash', opt.v)} style={{
-              borderRadius: 8, padding: '10px 18px', fontSize: 14, fontWeight: 600, minHeight: 44, cursor: 'pointer',
-              border: '1px solid', fontFamily: 'var(--font)',
-              background: form.crash === opt.v ? (opt.v ? 'var(--red-d)' : 'var(--grn-d)') : 'var(--card)',
-              color: form.crash === opt.v ? (opt.v ? 'var(--red)' : 'var(--grn)') : 'var(--tx-m)',
-              borderColor: form.crash === opt.v ? (opt.v ? 'rgba(248,113,113,0.3)' : 'rgba(74,222,128,0.3)') : 'var(--border)',
-            }}>{opt.l}</button>
-          ))}
-        </div>
-
-        <SectionLabel>Comments</SectionLabel>
-        <div style={{ fontSize: 11, color: 'var(--tx-d)', marginBottom: 6 }}>Brief reminder, e.g. &quot;Shopping for 3 hours&quot;</div>
-        <textarea value={form.comments} maxLength={500} onChange={e => set('comments', e.target.value)}
-          rows={3} placeholder="A few words about the day&hellip;"
-          aria-label="Comments about the day"
-          style={{ ...s.input, resize: 'vertical', fontFamily: 'var(--font)' }} />
 
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 20 }}>
           <BtnS onClick={onCancel}>Cancel</BtnS>

--- a/src/LearnView.jsx
+++ b/src/LearnView.jsx
@@ -12,11 +12,24 @@ const PEM_DETAIL_CONTENT = [
   { type: 'p', text: 'This app\u2019s crash logging and pre-crash lookback features are designed to capture the delayed nature of PEM. By tracking activity levels alongside symptoms over time, you can identify the exertion patterns that precede your crashes \u2014 even when the delay makes the connection hard to see.' },
 ];
 
+const QUICK_VS_FULL_CONTENT = [
+  { type: 'p', text: 'This app offers two logging modes. You can switch between them at any time \u2014 your data is always preserved.' },
+  { type: 'heading', text: 'Quick Log' },
+  { type: 'p', text: 'Four fields: overall activity, overall symptoms, crash, and sleep quality. Designed for days when you have very little energy for tracking. Takes about 30 seconds. Use this when detailed logging would itself become exertion.' },
+  { type: 'heading', text: 'Full Log' },
+  { type: 'p', text: 'Captures physical, mental, and emotional activity separately, plus individual symptom scores (fatigue, pain, nausea/GI, brain fog) at three time periods (AM, midday, PM). Provides richer data for pattern analysis and correlations.' },
+  { type: 'heading', text: 'Which should I use?' },
+  { type: 'p', text: 'Consistency matters more than detail. A Quick Log entry every day is more useful than a Full Log entry once a week. On better days, Full Log gives deeper insight into what triggers your crashes. On harder days, Quick Log keeps your streak going without adding to your exertion. The crash risk indicator and trend analysis work with both modes.' },
+  { type: 'heading', text: 'A note on symptom scores' },
+  { type: 'p', text: 'Quick Log\u2019s overall symptom score is a single end-of-day rating: "how were my symptoms today overall." Full Log\u2019s overall symptom is computed from three time-period observations. These measure slightly different things, but for crash pattern detection and trend analysis, both are effective.' },
+];
+
 const SECTIONS = [
   { id: 'what', t: 'What is PEM?', c: 'Post-Exertional Malaise (PEM) is the worsening of symptoms after physical, cognitive, or emotional exertion. It is one of the defining criteria of ME/CFS diagnosis. Crashes can be delayed by hours or even days after the triggering activity, making it difficult to identify what caused them.' },
   { id: 'pem-detail', t: 'Understanding PEM: How It Differs', c: PEM_DETAIL_CONTENT },
   { id: 'pacing', t: 'Pacing \u2014 The Key Strategy', c: 'Experts consider pacing to be the single most important strategy for reducing PEM crashes. The goal is to remain as active as your limited energy allows while taking proactive steps to avoid reaching your personal overexertion point. Set your constraints BEFORE you begin an activity. Use timers. Stop immediately when you sense warning signs. Don\u2019t try to push through when you feel sick or tired.' },
   { id: 'tracking', t: 'Why Track?', c: 'Patients who track their activities and symptoms find it easier to determine what might be causing crashes and which strategies help reduce them. Rate physical, mental, and emotional activity levels (0-10) and key symptoms (fatigue, pain, nausea/GI, brain fog) at three times each day (AM, midday, PM). Track crashes and brief comments. Look for patterns over weeks \u2014 crashes can be delayed 3-5 days from the triggering activity.' },
+  { id: 'quick-vs-full', t: 'Quick Log vs Full Log', c: QUICK_VS_FULL_CONTENT },
   { id: 'support', t: 'Building a Support Team', c: 'Share your crash avoidance plan with the people in your life who can help. Your support team can assist with tracking, pattern recognition, meal preparation, errands, and emotional encouragement. Help them understand ME/CFS \u2014 it\u2019s an invisible illness. Don\u2019t depend on just one person; maintain the strength of your support community.' },
   { id: 'steps', t: 'The 4 Steps', c: '1) Find your causes and barriers \u2014 what triggers PEM and what stops you from avoiding it. 2) Pick your strategies \u2014 choose approaches to overcome your barriers. 3) Share with your support team \u2014 implement your plan to the best of your ability. 4) Track your progress \u2014 understand how activities and strategies correlate with symptoms.' },
   { id: 'tips', t: 'Key Tips', c: 'Schedule rest even if you don\u2019t think you need it. Plan rest before AND after big activities. Reduce, simplify, and delegate. Eat regular, healthy meals and stay hydrated. Create a good sleep environment. Be kind to yourself \u2014 sometimes crashes happen involuntarily and it\u2019s not your fault. Stressing out is mental exertion that can trigger PEM.' },

--- a/src/LearnView.jsx
+++ b/src/LearnView.jsx
@@ -1,14 +1,56 @@
 import { useState } from 'react';
 import { Card } from './components.jsx';
 
+const PEM_DETAIL_CONTENT = [
+  { type: 'p', text: 'Post-Exertional Malaise is characterized by a delayed onset (typically 12\u201372 hours after exertion) of symptom worsening, with recovery time disproportionate to the activity that triggered it. Unlike normal tiredness, PEM can be triggered by minimal physical, cognitive, or emotional effort.' },
+  { type: 'heading', text: 'How PEM differs from similar conditions' },
+  { type: 'dt', term: 'Dysautonomia', text: 'Autonomic symptoms (heart rate, blood pressure, temperature regulation) occur during or immediately after exertion, not with a delayed onset. PEM involves systemic symptom worsening that appears hours to days later.' },
+  { type: 'dt', term: 'Mast Cell Activation Syndrome (MCAS)', text: 'Flares are triggered by specific exposures (foods, chemicals, temperature changes), not by exertion level. Symptoms include histamine-mediated reactions (flushing, hives, GI distress) rather than the systemic post-exertional pattern of PEM.' },
+  { type: 'dt', term: 'Fibromyalgia', text: 'Activity can worsen pain, but this typically occurs during or shortly after the activity without the characteristic delayed onset of PEM. Fibromyalgia pain is primarily musculoskeletal rather than systemic.' },
+  { type: 'dt', term: 'Delayed Onset Muscle Soreness (DOMS)', text: 'Predictable muscular soreness 24\u201372 hours after unaccustomed exercise. DOMS is localized to exercised muscles and resolves within days. PEM is systemic, can be triggered by cognitive or emotional effort, and recovery is disproportionately prolonged.' },
+  { type: 'heading', text: 'Why this matters for tracking' },
+  { type: 'p', text: 'This app\u2019s crash logging and pre-crash lookback features are designed to capture the delayed nature of PEM. By tracking activity levels alongside symptoms over time, you can identify the exertion patterns that precede your crashes \u2014 even when the delay makes the connection hard to see.' },
+];
+
 const SECTIONS = [
   { id: 'what', t: 'What is PEM?', c: 'Post-Exertional Malaise (PEM) is the worsening of symptoms after physical, cognitive, or emotional exertion. It is one of the defining criteria of ME/CFS diagnosis. Crashes can be delayed by hours or even days after the triggering activity, making it difficult to identify what caused them.' },
-  { id: 'pacing', t: 'Pacing — The Key Strategy', c: 'Experts consider pacing to be the single most important strategy for reducing PEM crashes. The goal is to remain as active as your limited energy allows while taking proactive steps to avoid reaching your personal overexertion point. Set your constraints BEFORE you begin an activity. Use timers. Stop immediately when you sense warning signs. Don’t try to push through when you feel sick or tired.' },
-  { id: 'tracking', t: 'Why Track?', c: 'Patients who track their activities and symptoms find it easier to determine what might be causing crashes and which strategies help reduce them. Rate physical, mental, and emotional activity levels (0-10) and key symptoms (fatigue, pain, nausea/GI, brain fog) at three times each day (AM, midday, PM). Track crashes and brief comments. Look for patterns over weeks — crashes can be delayed 3-5 days from the triggering activity.' },
-  { id: 'support', t: 'Building a Support Team', c: 'Share your crash avoidance plan with the people in your life who can help. Your support team can assist with tracking, pattern recognition, meal preparation, errands, and emotional encouragement. Help them understand ME/CFS — it’s an invisible illness. Don’t depend on just one person; maintain the strength of your support community.' },
-  { id: 'steps', t: 'The 4 Steps', c: '1) Find your causes and barriers — what triggers PEM and what stops you from avoiding it. 2) Pick your strategies — choose approaches to overcome your barriers. 3) Share with your support team — implement your plan to the best of your ability. 4) Track your progress — understand how activities and strategies correlate with symptoms.' },
-  { id: 'tips', t: 'Key Tips', c: 'Schedule rest even if you don’t think you need it. Plan rest before AND after big activities. Reduce, simplify, and delegate. Eat regular, healthy meals and stay hydrated. Create a good sleep environment. Be kind to yourself — sometimes crashes happen involuntarily and it’s not your fault. Stressing out is mental exertion that can trigger PEM.' },
+  { id: 'pem-detail', t: 'Understanding PEM: How It Differs', c: PEM_DETAIL_CONTENT },
+  { id: 'pacing', t: 'Pacing \u2014 The Key Strategy', c: 'Experts consider pacing to be the single most important strategy for reducing PEM crashes. The goal is to remain as active as your limited energy allows while taking proactive steps to avoid reaching your personal overexertion point. Set your constraints BEFORE you begin an activity. Use timers. Stop immediately when you sense warning signs. Don\u2019t try to push through when you feel sick or tired.' },
+  { id: 'tracking', t: 'Why Track?', c: 'Patients who track their activities and symptoms find it easier to determine what might be causing crashes and which strategies help reduce them. Rate physical, mental, and emotional activity levels (0-10) and key symptoms (fatigue, pain, nausea/GI, brain fog) at three times each day (AM, midday, PM). Track crashes and brief comments. Look for patterns over weeks \u2014 crashes can be delayed 3-5 days from the triggering activity.' },
+  { id: 'support', t: 'Building a Support Team', c: 'Share your crash avoidance plan with the people in your life who can help. Your support team can assist with tracking, pattern recognition, meal preparation, errands, and emotional encouragement. Help them understand ME/CFS \u2014 it\u2019s an invisible illness. Don\u2019t depend on just one person; maintain the strength of your support community.' },
+  { id: 'steps', t: 'The 4 Steps', c: '1) Find your causes and barriers \u2014 what triggers PEM and what stops you from avoiding it. 2) Pick your strategies \u2014 choose approaches to overcome your barriers. 3) Share with your support team \u2014 implement your plan to the best of your ability. 4) Track your progress \u2014 understand how activities and strategies correlate with symptoms.' },
+  { id: 'tips', t: 'Key Tips', c: 'Schedule rest even if you don\u2019t think you need it. Plan rest before AND after big activities. Reduce, simplify, and delegate. Eat regular, healthy meals and stay hydrated. Create a good sleep environment. Be kind to yourself \u2014 sometimes crashes happen involuntarily and it\u2019s not your fault. Stressing out is mental exertion that can trigger PEM.' },
 ];
+
+function renderContent(c) {
+  if (typeof c === 'string') {
+    return <p style={{ fontSize: 14, color: 'var(--tx-m)', lineHeight: 1.7, margin: 0 }}>{c}</p>;
+  }
+  if (Array.isArray(c)) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {c.map((block, i) => {
+          if (block.type === 'p') {
+            return <p key={i} style={{ fontSize: 14, color: 'var(--tx-m)', lineHeight: 1.7, margin: 0 }}>{block.text}</p>;
+          }
+          if (block.type === 'heading') {
+            return <div key={i} style={{ fontSize: 13, fontWeight: 700, color: 'var(--tx)', marginTop: 4 }}>{block.text}</div>;
+          }
+          if (block.type === 'dt') {
+            return (
+              <div key={i} style={{ paddingLeft: 12, borderLeft: '3px solid var(--border)' }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--acc)', marginBottom: 2 }}>{block.term}</div>
+                <div style={{ fontSize: 13, color: 'var(--tx-m)', lineHeight: 1.6 }}>{block.text}</div>
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    );
+  }
+  return null;
+}
 
 export default function LearnView() {
   const [open, setOpen] = useState(null);
@@ -40,7 +82,7 @@ export default function LearnView() {
                 background: 'var(--surface)', border: '1px solid var(--border)', borderTop: 'none',
                 borderRadius: '0 0 12px 12px', padding: '16px 18px',
               }}>
-                <p style={{ fontSize: 14, color: 'var(--tx-m)', lineHeight: 1.7, margin: 0 }}>{sec.c}</p>
+                {renderContent(sec.c)}
               </div>
             )}
           </div>

--- a/src/TrackView.jsx
+++ b/src/TrackView.jsx
@@ -107,7 +107,12 @@ export default function TrackView({ data, onEditDay }) {
           cursor: 'pointer', width: '100%', textAlign: 'left', marginBottom: 8, fontFamily: 'var(--font)',
         }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
-            <span style={{ fontSize: 13, fontWeight: 600 }}>{formatDate(day.date)}</span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 13, fontWeight: 600 }}>{formatDate(day.date)}</span>
+              {day.entryMode === 'quick' && (
+                <span style={{ fontSize: 9, fontWeight: 600, color: 'var(--teal)', background: 'rgba(45,212,191,0.12)', padding: '2px 8px', borderRadius: 4 }}>Quick</span>
+              )}
+            </div>
             {day.crash && <CrashBadge />}
           </div>
           <DaySummary day={day} compact />

--- a/src/db.js
+++ b/src/db.js
@@ -15,11 +15,19 @@ export function migrateData(stored) {
 
   const migrated = { ...stored };
 
-  // v1 → v2: backfill entryMode on existing day records
+  // v1 → v2: backfill entryMode and override flags on existing day records
   if (version < 2 && Array.isArray(migrated.days)) {
-    migrated.days = migrated.days.map(day =>
-      day.entryMode ? day : { ...day, entryMode: 'full' }
-    );
+    migrated.days = migrated.days.map(day => {
+      const updated = day.entryMode ? day : { ...day, entryMode: 'full' };
+      if (updated.overrideActivity === undefined) {
+        updated.overrideActivity = updated.overall_activity !== '' && updated.overall_activity != null;
+      }
+      if (updated.overrideSymptom === undefined) {
+        const os = updated.overall_symptom || { am: '', mid: '', pm: '' };
+        updated.overrideSymptom = os.am !== '' || os.mid !== '' || os.pm !== '';
+      }
+      return updated;
+    });
   }
 
   migrated.schemaVersion = DATA_SCHEMA_VERSION;

--- a/src/db.js
+++ b/src/db.js
@@ -2,6 +2,30 @@ const DB_NAME = 'pem_toolkit_db';
 const DB_VERSION = 1;
 const STORE = 'data';
 
+// App-level data schema version (separate from IndexedDB version).
+// Increment when adding new fields to stored data that need backfilling.
+export const DATA_SCHEMA_VERSION = 2;
+
+// Migrate stored app data to the current schema version.
+// Non-destructive and additive — only adds missing fields, never removes data.
+export function migrateData(stored) {
+  if (!stored) return stored;
+  const version = stored.schemaVersion || 1;
+  if (version >= DATA_SCHEMA_VERSION) return stored;
+
+  const migrated = { ...stored };
+
+  // v1 → v2: backfill entryMode on existing day records
+  if (version < 2 && Array.isArray(migrated.days)) {
+    migrated.days = migrated.days.map(day =>
+      day.entryMode ? day : { ...day, entryMode: 'full' }
+    );
+  }
+
+  migrated.schemaVersion = DATA_SCHEMA_VERSION;
+  return migrated;
+}
+
 function openDB() {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,6 +78,7 @@ export function emptyDay(date) {
   return {
     id: `day-${date}`,
     date,
+    entryMode: 'full',
     physical: '', mental: '', emotional: '', overall_activity: '',
     overrideActivity: false, overrideSymptom: false,
     unrefreshing_sleep: null,
@@ -94,7 +95,7 @@ export function emptyDay(date) {
 
 export function generateCSV(days) {
   const headers = [
-    'Date', 'Physical', 'Mental', 'Emotional', 'Overall Activity',
+    'Date', 'Entry Mode', 'Physical', 'Mental', 'Emotional', 'Overall Activity',
     'Unrefreshing Sleep', 'Fatigue AM', 'Fatigue Mid', 'Fatigue PM',
     'Pain AM', 'Pain Mid', 'Pain PM', 'Nausea/GI AM', 'Nausea/GI Mid', 'Nausea/GI PM',
     'Brain Fog AM', 'Brain Fog Mid', 'Brain Fog PM',
@@ -111,7 +112,7 @@ export function generateCSV(days) {
   const rows = [headers.join(',')];
   days.forEach(d => {
     rows.push([
-      d.date, d.physical, d.mental, d.emotional, d.overall_activity,
+      d.date, d.entryMode || 'full', d.physical, d.mental, d.emotional, d.overall_activity,
       d.unrefreshing_sleep === true ? 'Yes' : d.unrefreshing_sleep === false ? 'No' : '',
       d.fatigue?.am, d.fatigue?.mid, d.fatigue?.pm,
       d.pain?.am, d.pain?.mid, d.pain?.pm,
@@ -237,15 +238,16 @@ export function generateExportText(days, plan) {
   }
 
   lines.push('=== TRACKING DATA ===', '');
-  lines.push('Date       | Activity | Symptom | Sleep     | Crash | Comments');
-  lines.push('-'.repeat(75));
+  lines.push('Date       | Mode  | Activity | Symptom | Sleep     | Crash | Comments');
+  lines.push('-'.repeat(85));
   days.forEach(d => {
+    const mode = (d.entryMode || 'full').padEnd(5);
     const sym = avgField(d.overall_symptom);
     const symStr = sym !== null ? sym.toFixed(1).padEnd(7) : '  -    ';
     const slp = d.unrefreshing_sleep === true ? 'Unrefresh' : d.unrefreshing_sleep === false ? 'OK       ' : '  -      ';
     const crash = d.crash === true ? 'YES  ' : d.crash === false ? 'No   ' : '  -  ';
     const act = d.overall_activity != null && d.overall_activity !== '' ? String(d.overall_activity).padEnd(8) : '  -     ';
-    lines.push(`${d.date} | ${act} | ${symStr} | ${slp} | ${crash} | ${d.comments || ''}`);
+    lines.push(`${d.date} | ${mode} | ${act} | ${symStr} | ${slp} | ${crash} | ${d.comments || ''}`);
   });
 
   return lines.join('\n');

--- a/src/utils.js
+++ b/src/utils.js
@@ -74,6 +74,18 @@ export function calcOverallSymptom(form, period) {
   return vals.length > 0 ? vals.reduce((a, b) => a + b, 0) / vals.length : null;
 }
 
+export function hasGranularData(form) {
+  if (form.physical !== '' || form.mental !== '' || form.emotional !== '') return true;
+  for (const field of ['fatigue', 'pain', 'nausea_gi', 'brain_fog']) {
+    const f = form[field];
+    if (f && (f.am !== '' || f.mid !== '' || f.pm !== '')) return true;
+  }
+  if (form.other_symptom && form.other_symptom.name) return true;
+  return false;
+}
+
+// Field naming: legacy fields use snake_case (overall_activity, unrefreshing_sleep);
+// newer fields added in v2 use camelCase (entryMode, overrideActivity, overrideSymptom).
 export function emptyDay(date) {
   return {
     id: `day-${date}`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,6 +96,7 @@ export function emptyDay(date) {
 export function generateCSV(days) {
   const headers = [
     'Date', 'Entry Mode', 'Physical', 'Mental', 'Emotional', 'Overall Activity',
+    'Activity Override', 'Symptom Override',
     'Unrefreshing Sleep', 'Fatigue AM', 'Fatigue Mid', 'Fatigue PM',
     'Pain AM', 'Pain Mid', 'Pain PM', 'Nausea/GI AM', 'Nausea/GI Mid', 'Nausea/GI PM',
     'Brain Fog AM', 'Brain Fog Mid', 'Brain Fog PM',
@@ -113,6 +114,7 @@ export function generateCSV(days) {
   days.forEach(d => {
     rows.push([
       d.date, d.entryMode || 'full', d.physical, d.mental, d.emotional, d.overall_activity,
+      d.overrideActivity ? 'Yes' : 'No', d.overrideSymptom ? 'Yes' : 'No',
       d.unrefreshing_sleep === true ? 'Yes' : d.unrefreshing_sleep === false ? 'No' : '',
       d.fatigue?.am, d.fatigue?.mid, d.fatigue?.pm,
       d.pain?.am, d.pain?.mid, d.pain?.pm,

--- a/tests/e2e/features.test.js
+++ b/tests/e2e/features.test.js
@@ -490,6 +490,17 @@ test.describe('Learn Section - PEM Definition', () => {
     await expect(page.getByText('Delayed Onset Muscle Soreness (DOMS)')).toBeVisible({ timeout: 2000 });
   });
 
+  test('shows Quick Log vs Full Log section', async ({ page }) => {
+    await completeOnboarding(page);
+    await page.getByLabel('Learn').click();
+    await page.waitForTimeout(500);
+    await expect(page.getByText('Quick Log vs Full Log')).toBeVisible({ timeout: 3000 });
+    // Expand it
+    await page.getByText('Quick Log vs Full Log').click();
+    await page.waitForTimeout(300);
+    await expect(page.getByText('Consistency matters more than detail')).toBeVisible({ timeout: 2000 });
+  });
+
   test('PEM section mentions crash logging connection', async ({ page }) => {
     await completeOnboarding(page);
     await page.getByLabel('Learn').click();

--- a/tests/e2e/features.test.js
+++ b/tests/e2e/features.test.js
@@ -379,6 +379,128 @@ test.describe('Auto-Calculate Overall Symptom', () => {
   });
 });
 
+// ========== Quick Log Mode ==========
+
+test.describe('Quick Log - Mode Selector', () => {
+  test('shows Quick Log and Full Log mode selector in day editor', async ({ page }) => {
+    await openDayEditor(page);
+    await expect(page.getByRole('radio', { name: 'Quick Log' })).toBeVisible({ timeout: 2000 });
+    await expect(page.getByRole('radio', { name: 'Full Log' })).toBeVisible({ timeout: 2000 });
+    // Full Log should be active by default
+    const fullBtn = page.getByRole('radio', { name: 'Full Log' });
+    await expect(fullBtn).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('Quick Log mode shows only essential fields', async ({ page }) => {
+    await openDayEditor(page);
+    // Switch to Quick Log
+    await page.getByRole('radio', { name: 'Quick Log' }).click();
+    await page.waitForTimeout(300);
+    // Quick Log fields should be visible
+    await expect(page.locator('[aria-label="Overall Activity score selector"]')).toBeVisible({ timeout: 2000 });
+    await expect(page.locator('[aria-label="Overall Symptoms score selector"]')).toBeVisible({ timeout: 2000 });
+    await expect(page.locator('[aria-label="Crash today"]')).toBeVisible({ timeout: 2000 });
+    await expect(page.locator('[aria-label="Sleep quality"]')).toBeVisible({ timeout: 2000 });
+    // Full Log fields should NOT be visible
+    await expect(page.locator('[aria-label="Physical score selector"]')).not.toBeVisible({ timeout: 1000 });
+    await expect(page.locator('[aria-label="Mental score selector"]')).not.toBeVisible({ timeout: 1000 });
+    await expect(page.locator('[aria-label="Emotional score selector"]')).not.toBeVisible({ timeout: 1000 });
+  });
+
+  test('saves Quick Log entry and shows in recent entries with Quick badge', async ({ page }) => {
+    await openDayEditor(page);
+    await page.getByRole('radio', { name: 'Quick Log' }).click();
+    await page.waitForTimeout(300);
+    // Fill required fields
+    const actGroup = page.locator('[aria-label="Overall Activity score selector"]');
+    await actGroup.getByRole('radio', { name: '5', exact: true }).click();
+    const symGroup = page.locator('[aria-label="Overall Symptoms score selector"]');
+    await symGroup.getByRole('radio', { name: '3', exact: true }).click();
+    // Set crash to No
+    await page.locator('[aria-label="Crash today"]').getByRole('radio', { name: 'No' }).click();
+    // Set sleep to Refreshing
+    await page.locator('[aria-label="Sleep quality"]').getByRole('radio', { name: 'Refreshing', exact: true }).click();
+    // Save
+    await page.getByText('Save').first().click();
+    await page.waitForTimeout(500);
+    // Verify entry appears in recent entries with Quick badge
+    // The Quick badge is a span inside the recent entry
+    await expect(page.locator('span').filter({ hasText: /^Quick$/ })).toBeVisible({ timeout: 2000 });
+  });
+});
+
+test.describe('Quick Log - Mode Switching', () => {
+  test('warns when switching from Full to Quick on existing entry with data', async ({ page }) => {
+    await openDayEditor(page);
+    // Fill some full-log data
+    await selectScore(page, 'Physical', 5);
+    await selectScore(page, 'Mental', 3);
+    await page.waitForTimeout(300);
+    // Set up dialog handler before clicking
+    page.on('dialog', dialog => dialog.dismiss());
+    // Try switching to Quick mode
+    await page.getByRole('radio', { name: 'Quick Log' }).click();
+    await page.waitForTimeout(300);
+    // Should still be in Full Log mode (dismissed the confirm)
+    const fullBtn = page.getByRole('radio', { name: 'Full Log' });
+    await expect(fullBtn).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('preserves full data when switching to Quick and back', async ({ page }) => {
+    await openDayEditor(page);
+    // Fill some full-log data
+    await selectScore(page, 'Physical', 7);
+    await page.waitForTimeout(300);
+    // Accept the confirm dialog
+    page.on('dialog', dialog => dialog.accept());
+    // Switch to Quick
+    await page.getByRole('radio', { name: 'Quick Log' }).click();
+    await page.waitForTimeout(300);
+    // Switch back to Full
+    await page.getByRole('radio', { name: 'Full Log' }).click();
+    await page.waitForTimeout(300);
+    // Physical score 7 should still be selected
+    const physGroup = page.locator('[aria-label="Physical score selector"]');
+    const radio7 = physGroup.getByRole('radio', { name: '7', exact: true });
+    await expect(radio7).toHaveAttribute('aria-checked', 'true');
+  });
+});
+
+// ========== Learn Section PEM Definition ==========
+
+test.describe('Learn Section - PEM Definition', () => {
+  test('shows Understanding PEM: How It Differs section', async ({ page }) => {
+    await completeOnboarding(page);
+    await page.getByLabel('Learn').click();
+    await page.waitForTimeout(500);
+    await expect(page.getByText('Understanding PEM: How It Differs')).toBeVisible({ timeout: 3000 });
+  });
+
+  test('PEM section contains differential diagnosis content', async ({ page }) => {
+    await completeOnboarding(page);
+    await page.getByLabel('Learn').click();
+    await page.waitForTimeout(500);
+    // Click to expand
+    await page.getByText('Understanding PEM: How It Differs').click();
+    await page.waitForTimeout(300);
+    // Verify differential conditions are listed
+    await expect(page.getByText('Dysautonomia')).toBeVisible({ timeout: 2000 });
+    await expect(page.getByText('Mast Cell Activation Syndrome (MCAS)')).toBeVisible({ timeout: 2000 });
+    await expect(page.getByText('Fibromyalgia', { exact: true })).toBeVisible({ timeout: 2000 });
+    await expect(page.getByText('Delayed Onset Muscle Soreness (DOMS)')).toBeVisible({ timeout: 2000 });
+  });
+
+  test('PEM section mentions crash logging connection', async ({ page }) => {
+    await completeOnboarding(page);
+    await page.getByLabel('Learn').click();
+    await page.waitForTimeout(500);
+    await page.getByText('Understanding PEM: How It Differs').click();
+    await page.waitForTimeout(300);
+    await expect(page.getByText(/crash logging/i)).toBeVisible({ timeout: 2000 });
+    await expect(page.getByText(/pre-crash lookback/i)).toBeVisible({ timeout: 2000 });
+  });
+});
+
 test.describe('Auto-Calculate Save & Reload', () => {
   test('auto-calculated values persist after save and re-open', async ({ page }) => {
     await openDayEditor(page);

--- a/tests/unit/db-new.test.js
+++ b/tests/unit/db-new.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { dbGet, dbSet, dbExportAll, dbImportAll } from '../../src/db.js';
+import { dbGet, dbSet, dbExportAll, dbImportAll, migrateData } from '../../src/db.js';
 
 beforeEach(() => {
   indexedDB = new IDBFactory();
@@ -107,5 +107,85 @@ describe('dbImportAll', () => {
       const val = await dbGet(`key-${i}`);
       expect(val).toEqual({ index: i });
     }
+  });
+});
+
+describe('migrateData - override flag backfill', () => {
+  it('sets overrideActivity true when overall_activity has a value', () => {
+    const stored = {
+      days: [{ date: '2024-01-01', overall_activity: '5' }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideActivity).toBe(true);
+  });
+
+  it('sets overrideActivity false when overall_activity is empty', () => {
+    const stored = {
+      days: [{ date: '2024-01-01', overall_activity: '' }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideActivity).toBe(false);
+  });
+
+  it('sets overrideActivity false when overall_activity is null', () => {
+    const stored = {
+      days: [{ date: '2024-01-01', overall_activity: null }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideActivity).toBe(false);
+  });
+
+  it('sets overrideSymptom true when any symptom period is filled', () => {
+    const stored = {
+      days: [{ date: '2024-01-01', overall_symptom: { am: '4', mid: '', pm: '' } }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideSymptom).toBe(true);
+  });
+
+  it('sets overrideSymptom false when all symptom periods are empty', () => {
+    const stored = {
+      days: [{ date: '2024-01-01', overall_symptom: { am: '', mid: '', pm: '' } }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideSymptom).toBe(false);
+  });
+
+  it('sets overrideSymptom false when overall_symptom is missing', () => {
+    const stored = {
+      days: [{ date: '2024-01-01' }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideSymptom).toBe(false);
+  });
+
+  it('preserves existing override flags and does not re-infer', () => {
+    const stored = {
+      schemaVersion: 1,
+      days: [{
+        date: '2024-01-01',
+        overall_activity: '5',
+        overrideActivity: false,
+        overrideSymptom: true,
+      }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].overrideActivity).toBe(false);
+    expect(result.days[0].overrideSymptom).toBe(true);
+  });
+
+  it('backfills entryMode and override flags together', () => {
+    const stored = {
+      days: [{
+        date: '2024-01-01',
+        overall_activity: '7',
+        overall_symptom: { am: '3', mid: '5', pm: '4' },
+      }],
+    };
+    const result = migrateData(stored);
+    expect(result.days[0].entryMode).toBe('full');
+    expect(result.days[0].overrideActivity).toBe(true);
+    expect(result.days[0].overrideSymptom).toBe(true);
+    expect(result.schemaVersion).toBe(2);
   });
 });

--- a/tests/unit/utils-new.test.js
+++ b/tests/unit/utils-new.test.js
@@ -8,6 +8,7 @@ import {
   emptyDay,
   avgField,
 } from '../../src/utils.js';
+import { migrateData, DATA_SCHEMA_VERSION } from '../../src/db.js';
 
 // --- Helper: create a day with specific values ---
 function makeDay(date, overrides = {}) {
@@ -544,5 +545,111 @@ describe('Quick Log - avgField with single period', () => {
 
   it('returns null when all periods are empty', () => {
     expect(avgField({ am: '', mid: '', pm: '' })).toBeNull();
+  });
+});
+
+// --- Data Migration ---
+
+describe('migrateData', () => {
+  it('returns null/undefined input unchanged', () => {
+    expect(migrateData(null)).toBeNull();
+    expect(migrateData(undefined)).toBeUndefined();
+  });
+
+  it('backfills entryMode on legacy day records without it', () => {
+    const stored = {
+      days: [
+        { date: '2024-01-01', physical: '3', mental: '4' },
+        { date: '2024-01-02', physical: '5' },
+      ],
+      plan: { causes: [], barriers: [], strategies: [] },
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.days[0].entryMode).toBe('full');
+    expect(migrated.days[1].entryMode).toBe('full');
+  });
+
+  it('does not overwrite existing entryMode values', () => {
+    const stored = {
+      days: [
+        { date: '2024-01-01', entryMode: 'quick', overall_activity: '5' },
+        { date: '2024-01-02', entryMode: 'full', physical: '3' },
+      ],
+      plan: { causes: [], barriers: [], strategies: [] },
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.days[0].entryMode).toBe('quick');
+    expect(migrated.days[1].entryMode).toBe('full');
+  });
+
+  it('sets schemaVersion to current DATA_SCHEMA_VERSION', () => {
+    const stored = {
+      days: [{ date: '2024-01-01' }],
+      plan: { causes: [], barriers: [], strategies: [] },
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.schemaVersion).toBe(DATA_SCHEMA_VERSION);
+  });
+
+  it('skips migration if schemaVersion is already current', () => {
+    const stored = {
+      schemaVersion: DATA_SCHEMA_VERSION,
+      days: [
+        { date: '2024-01-01' }, // no entryMode — but migration should NOT run
+      ],
+      plan: { causes: [], barriers: [], strategies: [] },
+    };
+    const migrated = migrateData(stored);
+    // Should be returned as-is (same reference)
+    expect(migrated).toBe(stored);
+    // entryMode was NOT added since migration was skipped
+    expect(migrated.days[0].entryMode).toBeUndefined();
+  });
+
+  it('is non-destructive — preserves all existing fields', () => {
+    const stored = {
+      days: [{
+        date: '2024-01-01',
+        physical: '3',
+        mental: '5',
+        emotional: '2',
+        overall_activity: '4',
+        fatigue: { am: '3', mid: '4', pm: '5' },
+        crash: true,
+        comments: 'bad day',
+      }],
+      plan: { causes: ['heat'], barriers: ['work'], strategies: ['rest'] },
+      onboarded: true,
+      theme: 'light',
+      tourCompleted: true,
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.days[0].physical).toBe('3');
+    expect(migrated.days[0].mental).toBe('5');
+    expect(migrated.days[0].crash).toBe(true);
+    expect(migrated.days[0].comments).toBe('bad day');
+    expect(migrated.plan.causes).toEqual(['heat']);
+    expect(migrated.onboarded).toBe(true);
+    expect(migrated.theme).toBe('light');
+  });
+
+  it('handles empty days array', () => {
+    const stored = {
+      days: [],
+      plan: { causes: [], barriers: [], strategies: [] },
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.days).toEqual([]);
+    expect(migrated.schemaVersion).toBe(DATA_SCHEMA_VERSION);
+  });
+
+  it('handles stored data without days array', () => {
+    const stored = {
+      plan: { causes: [], barriers: [], strategies: [] },
+      onboarded: true,
+    };
+    const migrated = migrateData(stored);
+    expect(migrated.schemaVersion).toBe(DATA_SCHEMA_VERSION);
+    expect(migrated.plan).toBeDefined();
   });
 });

--- a/tests/unit/utils-new.test.js
+++ b/tests/unit/utils-new.test.js
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   generateCSV,
+  generateExportText,
   computeCorrelations,
   computeCrashRisk,
   getLast30Dates,
   emptyDay,
+  avgField,
 } from '../../src/utils.js';
 
 // --- Helper: create a day with specific values ---
@@ -33,11 +35,12 @@ describe('generateCSV', () => {
   it('includes all expected column headers', () => {
     const csv = generateCSV([]);
     const headers = csv.split('\n')[0].split(',');
-    expect(headers).toHaveLength(27);
+    expect(headers).toHaveLength(28);
     expect(headers[0]).toBe('Date');
-    expect(headers[5]).toBe('Unrefreshing Sleep');
-    expect(headers[25]).toBe('Crash');
-    expect(headers[26]).toBe('Comments');
+    expect(headers[1]).toBe('Entry Mode');
+    expect(headers[6]).toBe('Unrefreshing Sleep');
+    expect(headers[26]).toBe('Crash');
+    expect(headers[27]).toBe('Comments');
   });
 
   it('generates one data row per day', () => {
@@ -56,10 +59,10 @@ describe('generateCSV', () => {
       makeDay('2024-01-17', { unrefreshing_sleep: null }),
     ];
     const lines = generateCSV(days).split('\n');
-    // sleep is column index 5
-    expect(lines[1].split(',')[5]).toBe('Yes');
-    expect(lines[2].split(',')[5]).toBe('No');
-    expect(lines[3].split(',')[5]).toBe('');
+    // sleep is column index 6 (Date, Entry Mode, Physical, Mental, Emotional, Overall Activity, Unrefreshing Sleep)
+    expect(lines[1].split(',')[6]).toBe('Yes');
+    expect(lines[2].split(',')[6]).toBe('No');
+    expect(lines[3].split(',')[6]).toBe('');
   });
 
   it('maps crash field correctly', () => {
@@ -69,10 +72,10 @@ describe('generateCSV', () => {
       makeDay('2024-01-17', { crash: null }),
     ];
     const lines = generateCSV(days).split('\n');
-    // crash is column index 25 (shifted by 4 for other_symptom columns)
-    expect(lines[1].split(',')[25]).toBe('Yes');
-    expect(lines[2].split(',')[25]).toBe('No');
-    expect(lines[3].split(',')[25]).toBe('');
+    // crash is column index 26 (shifted +1 for Entry Mode column)
+    expect(lines[1].split(',')[26]).toBe('Yes');
+    expect(lines[2].split(',')[26]).toBe('No');
+    expect(lines[3].split(',')[26]).toBe('');
   });
 
   it('includes symptom AM/Mid/PM values', () => {
@@ -366,5 +369,180 @@ describe('getLast30Dates', () => {
       const expected = `${prev.getFullYear()}-${String(prev.getMonth()+1).padStart(2,'0')}-${String(prev.getDate()).padStart(2,'0')}`;
       expect(dates[i]).toBe(expected);
     }
+  });
+});
+
+// --- Quick Log: entryMode data model ---
+
+describe('Quick Log - emptyDay entryMode', () => {
+  it('emptyDay includes entryMode: "full" by default', () => {
+    const day = emptyDay('2024-01-15');
+    expect(day.entryMode).toBe('full');
+  });
+
+  it('makeDay preserves entryMode when set to quick', () => {
+    const day = makeDay('2024-01-15', { entryMode: 'quick' });
+    expect(day.entryMode).toBe('quick');
+  });
+
+  it('Quick Log entry has null individual dimensions and only overall fields', () => {
+    const day = makeDay('2024-01-15', {
+      entryMode: 'quick',
+      overall_activity: '5',
+      overrideActivity: true,
+      overall_symptom: { am: '6', mid: '', pm: '' },
+      overrideSymptom: true,
+      crash: false,
+      unrefreshing_sleep: true,
+      // physical, mental, emotional remain empty from emptyDay
+    });
+    expect(day.entryMode).toBe('quick');
+    expect(day.overall_activity).toBe('5');
+    expect(day.overall_symptom.am).toBe('6');
+    expect(day.overall_symptom.mid).toBe('');
+    expect(day.overall_symptom.pm).toBe('');
+    expect(day.physical).toBe('');
+    expect(day.mental).toBe('');
+    expect(day.emotional).toBe('');
+  });
+});
+
+// --- Quick Log: CSV export ---
+
+describe('Quick Log - generateCSV with entryMode', () => {
+  it('includes Entry Mode column header', () => {
+    const csv = generateCSV([]);
+    const headers = csv.split('\n')[0].split(',');
+    expect(headers).toContain('Entry Mode');
+    expect(headers).toHaveLength(28);
+  });
+
+  it('Quick Log rows have "quick" in Entry Mode column', () => {
+    const days = [makeDay('2024-01-15', {
+      entryMode: 'quick',
+      overall_activity: '5',
+      overall_symptom: { am: '6', mid: '', pm: '' },
+      crash: false,
+      unrefreshing_sleep: true,
+    })];
+    const csv = generateCSV(days);
+    const row = csv.split('\n')[1].split(',');
+    // Entry Mode is column index 1 (after Date)
+    expect(row[1]).toBe('quick');
+  });
+
+  it('Full Log rows have "full" in Entry Mode column', () => {
+    const days = [makeDay('2024-01-15', { entryMode: 'full', physical: '3' })];
+    const csv = generateCSV(days);
+    const row = csv.split('\n')[1].split(',');
+    expect(row[1]).toBe('full');
+  });
+
+  it('legacy entries without entryMode default to "full" in CSV', () => {
+    const day = makeDay('2024-01-15', { physical: '3' });
+    delete day.entryMode;
+    const csv = generateCSV([day]);
+    const row = csv.split('\n')[1].split(',');
+    expect(row[1]).toBe('full');
+  });
+
+  it('Quick Log rows have empty cells for individual dimensions', () => {
+    const days = [makeDay('2024-01-15', {
+      entryMode: 'quick',
+      overall_activity: '5',
+      overall_symptom: { am: '6', mid: '', pm: '' },
+    })];
+    const csv = generateCSV(days);
+    const row = csv.split('\n')[1].split(',');
+    // Physical is column index 2 (Date, Entry Mode, Physical)
+    expect(row[2]).toBe('');
+    expect(row[3]).toBe('');
+    expect(row[4]).toBe('');
+  });
+});
+
+// --- Quick Log: text export ---
+
+describe('Quick Log - generateExportText with entryMode', () => {
+  it('includes Mode column in text export header', () => {
+    const text = generateExportText([], { causes: [], barriers: [], strategies: [] });
+    expect(text).toContain('Mode');
+  });
+
+  it('shows quick mode in text export for quick entries', () => {
+    const days = [makeDay('2024-01-15', {
+      entryMode: 'quick',
+      overall_activity: '5',
+      overall_symptom: { am: '6', mid: '', pm: '' },
+      crash: false,
+      unrefreshing_sleep: false,
+    })];
+    const text = generateExportText(days, { causes: [], barriers: [], strategies: [] });
+    expect(text).toContain('quick');
+  });
+});
+
+// --- Quick Log: statistical calculations with null fields ---
+
+describe('Quick Log - computeCorrelations with null dimensions', () => {
+  it('handles Quick Log entries with null individual dimensions', () => {
+    // Mix of quick and full entries
+    const days = [
+      // 5 full entries
+      ...Array.from({ length: 5 }, (_, i) => makeDay(
+        `2024-01-${String(i + 1).padStart(2, '0')}`,
+        {
+          entryMode: 'full',
+          physical: String(i + 1),
+          mental: String(i + 2),
+          emotional: String(i),
+          overall_activity: String(i + 1),
+          fatigue: { am: String(i + 1), mid: String(i + 1), pm: String(i + 1) },
+          overall_symptom: { am: String(i + 1), mid: String(i + 1), pm: String(i + 1) },
+        }
+      )),
+      // 5 quick entries (no individual dimensions)
+      ...Array.from({ length: 5 }, (_, i) => makeDay(
+        `2024-01-${String(i + 6).padStart(2, '0')}`,
+        {
+          entryMode: 'quick',
+          overall_activity: String(i + 3),
+          overall_symptom: { am: String(i + 3), mid: '', pm: '' },
+        }
+      )),
+    ];
+    const result = computeCorrelations(days);
+    expect(result).toHaveProperty('labels');
+    expect(result).toHaveProperty('matrix');
+    // Physical only has 5 valid entries, so correlations involving it should still compute
+    const physIdx = result.labels.indexOf('Physical');
+    expect(physIdx).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('Quick Log - computeCrashRisk with quick entries', () => {
+  it('works correctly with Quick Log entries (uses overall_activity)', () => {
+    const days = Array.from({ length: 10 }, (_, i) => makeDay(
+      `2024-01-${String(i + 1).padStart(2, '0')}`,
+      {
+        entryMode: 'quick',
+        overall_activity: '4',
+        overall_symptom: { am: '3', mid: '', pm: '' },
+      }
+    ));
+    const result = computeCrashRisk(days);
+    expect(result).not.toBeNull();
+    expect(result.atRisk).toBe(false);
+    expect(result.mean).toBe('4.0');
+  });
+});
+
+describe('Quick Log - avgField with single period', () => {
+  it('returns the single value when only am is filled', () => {
+    expect(avgField({ am: '6', mid: '', pm: '' })).toBe(6);
+  });
+
+  it('returns null when all periods are empty', () => {
+    expect(avgField({ am: '', mid: '', pm: '' })).toBeNull();
   });
 });

--- a/tests/unit/utils-new.test.js
+++ b/tests/unit/utils-new.test.js
@@ -36,12 +36,14 @@ describe('generateCSV', () => {
   it('includes all expected column headers', () => {
     const csv = generateCSV([]);
     const headers = csv.split('\n')[0].split(',');
-    expect(headers).toHaveLength(28);
+    expect(headers).toHaveLength(30);
     expect(headers[0]).toBe('Date');
     expect(headers[1]).toBe('Entry Mode');
-    expect(headers[6]).toBe('Unrefreshing Sleep');
-    expect(headers[26]).toBe('Crash');
-    expect(headers[27]).toBe('Comments');
+    expect(headers[6]).toBe('Activity Override');
+    expect(headers[7]).toBe('Symptom Override');
+    expect(headers[8]).toBe('Unrefreshing Sleep');
+    expect(headers[28]).toBe('Crash');
+    expect(headers[29]).toBe('Comments');
   });
 
   it('generates one data row per day', () => {
@@ -60,10 +62,10 @@ describe('generateCSV', () => {
       makeDay('2024-01-17', { unrefreshing_sleep: null }),
     ];
     const lines = generateCSV(days).split('\n');
-    // sleep is column index 6 (Date, Entry Mode, Physical, Mental, Emotional, Overall Activity, Unrefreshing Sleep)
-    expect(lines[1].split(',')[6]).toBe('Yes');
-    expect(lines[2].split(',')[6]).toBe('No');
-    expect(lines[3].split(',')[6]).toBe('');
+    // sleep is column index 8 (Date, Entry Mode, Physical, Mental, Emotional, Overall Activity, Activity Override, Symptom Override, Unrefreshing Sleep)
+    expect(lines[1].split(',')[8]).toBe('Yes');
+    expect(lines[2].split(',')[8]).toBe('No');
+    expect(lines[3].split(',')[8]).toBe('');
   });
 
   it('maps crash field correctly', () => {
@@ -73,10 +75,10 @@ describe('generateCSV', () => {
       makeDay('2024-01-17', { crash: null }),
     ];
     const lines = generateCSV(days).split('\n');
-    // crash is column index 26 (shifted +1 for Entry Mode column)
-    expect(lines[1].split(',')[26]).toBe('Yes');
-    expect(lines[2].split(',')[26]).toBe('No');
-    expect(lines[3].split(',')[26]).toBe('');
+    // crash is column index 28 (shifted +2 for Activity Override, Symptom Override columns)
+    expect(lines[1].split(',')[28]).toBe('Yes');
+    expect(lines[2].split(',')[28]).toBe('No');
+    expect(lines[3].split(',')[28]).toBe('');
   });
 
   it('includes symptom AM/Mid/PM values', () => {
@@ -415,7 +417,9 @@ describe('Quick Log - generateCSV with entryMode', () => {
     const csv = generateCSV([]);
     const headers = csv.split('\n')[0].split(',');
     expect(headers).toContain('Entry Mode');
-    expect(headers).toHaveLength(28);
+    expect(headers).toContain('Activity Override');
+    expect(headers).toContain('Symptom Override');
+    expect(headers).toHaveLength(30);
   });
 
   it('Quick Log rows have "quick" in Entry Mode column', () => {


### PR DESCRIPTION
Quick Log mode provides a simplified 4-field entry (overall activity,
overall symptoms, crash, sleep) for severely affected ME/CFS patients.
Adds entryMode field to data model with backward-compatible fallback.
Learn section gains a new "Understanding PEM: How It Differs" accordion
differentiating PEM from Dysautonomia, MCAS, Fibromyalgia, and DOMS.

- Add entryMode to emptyDay(), generateCSV(), generateExportText()
- Add mode selector (Quick/Full) with accessible radiogroup in DayEditor
- Quick Log stores single symptom score without manufacturing data
- Warn on Full→Quick switch when granular data exists
- Show "Quick" badge on recent entries in TrackView
- Add PEM differential diagnosis section to LearnView
- Add unit tests for Quick Log data model, exports, and stats
- Add e2e tests for Quick Log workflow, mode switching, Learn section
- All 107 unit tests and 54 e2e tests pass

https://claude.ai/code/session_01Gk6aWUkCDwy6J5uZ1vtQsy