### PR TITLE
Update PEM toolkit attribution: developed at Stanford, hosted by OMF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PEM Avoidance Toolkit
 
-A progressive web app for tracking post-exertional malaise, based on the [Open Medicine Foundation](https://omf.ngo/pem-avoidance-toolkit) framework.
+A progressive web app for tracking post-exertional malaise, based on the Stanford PEM Avoidance Toolkit, hosted by the [Open Medicine Foundation](https://omf.ngo/pem-avoidance-toolkit).
 
 **All data stays on the user's device.** Nothing is ever sent to a server.
 
@@ -110,6 +110,6 @@ npm run build     # production build
 
 ## Based on
 
-The Open Medicine Foundation PEM Avoidance Toolkit, developed by Jeff Hewitt, Sarah Hewitt, Dana Beltramo Hewitt, Dr. Bonilla, and Dr. Montoya with input from ME/CFS patients.
+The PEM Avoidance Toolkit, developed at Stanford by Jeff Hewitt, Sarah Hewitt, Dana Beltramo Hewitt, Dr. Bonilla, and Dr. Montoya with input from ME/CFS patients. Hosted online by the Open Medicine Foundation.
 
 Full toolkit: [omf.ngo/pem-avoidance-toolkit](https://omf.ngo/pem-avoidance-toolkit)

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PEM Avoidance Toolkit",
   "short_name": "PEM Toolkit",
-  "description": "Track activities and symptoms to avoid post-exertional malaise. Based on the Open Medicine Foundation framework.",
+  "description": "Track activities and symptoms to avoid post-exertional malaise. Based on the Stanford PEM Avoidance Toolkit, hosted by Open Medicine Foundation.",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#0F1318",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ const TOUR_STEPS = [
   { tab: 'track', title: 'Track Your Day', desc: 'Log physical, mental, and emotional activity levels plus symptoms each day.' },
   { tab: 'patterns', title: 'See Your Patterns', desc: 'Discover what triggers crashes by reviewing trends and correlations.' },
   { tab: 'plan', title: 'Build Your Plan', desc: 'Identify causes, barriers, and strategies to prevent PEM crashes.' },
-  { tab: 'learn', title: 'Learn About PEM', desc: 'Reference material from the Open Medicine Foundation framework.' },
+  { tab: 'learn', title: 'Learn About PEM', desc: 'Reference material from the Stanford PEM Avoidance Toolkit, hosted by the Open Medicine Foundation.' },
 ];
 
 function LoadingFallback() {
@@ -199,7 +199,7 @@ export default function App() {
         <div style={{ fontSize: 64, marginBottom: 24 }}>{'\u26A1'}</div>
         <div style={{ fontSize: 24, fontWeight: 700, marginBottom: 12, lineHeight: 1.3 }}>PEM Avoidance Toolkit</div>
         <div style={{ fontSize: 15, color: 'var(--tx-m)', lineHeight: 1.7, marginBottom: 32, maxWidth: 380 }}>
-          Track your activities and symptoms to identify crash triggers and build your personalized avoidance plan. Based on the Open Medicine Foundation framework.
+          Track your activities and symptoms to identify crash triggers and build your personalized avoidance plan. Based on the Stanford PEM Avoidance Toolkit, hosted by the Open Medicine Foundation.
         </div>
         <div style={{ textAlign: 'left', marginBottom: 32, maxWidth: 380, width: '100%' }}>
           {[
@@ -240,7 +240,7 @@ export default function App() {
           <div style={{ width: 38, height: 38, borderRadius: 10, background: 'linear-gradient(135deg, var(--teal), var(--acc))', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, color: '#fff', flexShrink: 0 }}>{'\u26A1'}</div>
           <div style={{ flex: 1 }}>
             <h1 style={{ fontSize: 17, fontWeight: 700, letterSpacing: '-0.02em', lineHeight: 1.2 }}>PEM Avoidance Toolkit</h1>
-            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginTop: 2 }}>Open Medicine Foundation framework</div>
+            <div style={{ fontSize: 11, color: 'var(--tx-d)', marginTop: 2 }}>Stanford · Hosted by Open Medicine Foundation</div>
           </div>
           <div style={{ display: 'flex', gap: 6 }}>
             <button onClick={toggleTheme} aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'} style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--tx-m)', cursor: 'pointer', fontFamily: 'var(--font)', minHeight: 32 }}>

--- a/src/LearnView.jsx
+++ b/src/LearnView.jsx
@@ -17,7 +17,7 @@ export default function LearnView() {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 4 }}>Learn</div>
       <div style={{ fontSize: 12, color: 'var(--tx-d)', lineHeight: 1.6, marginBottom: 8 }}>
-        Reference material from the Open Medicine Foundation&rsquo;s PEM Avoidance Toolkit, developed by Jeff Hewitt, Sarah Hewitt, Dana Beltramo Hewitt, Dr. Bonilla, and Dr. Montoya with input from ME/CFS patients.
+        Reference material from the PEM Avoidance Toolkit, developed at Stanford by Jeff Hewitt, Sarah Hewitt, Dana Beltramo Hewitt, Dr. Bonilla, and Dr. Montoya with input from ME/CFS patients. Hosted online by the Open Medicine Foundation.
       </div>
 
       {SECTIONS.map(sec => {
@@ -75,7 +75,7 @@ export default function LearnView() {
         <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>About</div>
         <div style={{ fontSize: 13, color: 'var(--tx-m)', lineHeight: 1.7 }}>
           <p style={{ margin: '0 0 6px' }}>Developed by <a href="https://tickedoffcodess.com" target="_blank" rel="noopener noreferrer" style={{ fontWeight: 600, color: 'var(--acc)', textDecoration: 'none' }}>TickedOffCodess</a> with the help of <a href="https://claude.ai" target="_blank" rel="noopener noreferrer" style={{ fontWeight: 600, color: 'var(--acc)', textDecoration: 'none' }}>Claude</a>.</p>
-          <p style={{ margin: 0 }}>Based on the Open Medicine Foundation PEM Avoidance Toolkit.</p>
+          <p style={{ margin: 0 }}>Based on the PEM Avoidance Toolkit, developed at Stanford and hosted by the Open Medicine Foundation.</p>
         </div>
       </div>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -212,7 +212,7 @@ export function getLast30Dates() {
 export function generateExportText(days, plan) {
   const lines = [
     'PEM AVOIDANCE TOOLKIT - TRACKING DATA',
-    'Based on Open Medicine Foundation framework',
+    'Based on Stanford PEM Avoidance Toolkit, hosted by Open Medicine Foundation',
     'Generated: ' + new Date().toLocaleDateString(),
     '', '',
   ];


### PR DESCRIPTION
The PEM Avoidance Toolkit was built by Stanford and hosted online by
Open Medicine Foundation. Updated all attribution mentions across
README, LearnView, App, utils, and manifest to correctly reflect this.
Individual contributor names are preserved.

https://claude.ai/code/session_01R2L4bdkWgTLgnWhoxWpKGF